### PR TITLE
[PBI 2.1] SELECTのみ実行可能な安全なSQL実行基盤を使える

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -2,8 +2,8 @@
 
 ## 技術スタック
 - フロントエンド: React 18 + TypeScript + Vite 5
-- バックエンド: Node.js 20 + Express 4 + TypeScript
-- テスト: Playwright (E2E)
+- バックエンド: Node.js 20 + Express 4 + TypeScript + knex 3 (pg/mysql2)
+- テスト: Playwright (E2E) + Vitest (ユニット)
 - コンテナ: Docker Compose (ubuntu:24.04ベース)
 - パッケージ管理: npm workspaces
 
@@ -25,9 +25,20 @@ output_system/
 │       ├── main.tsx         # エントリポイント
 │       └── styles/global.css
 ├── backend/
-│   ├── package.json         # Express 4, cors, ts-node-dev
-│   └── src/index.ts         # GET /api/health エンドポイント
-└── test/e2e/app.spec.ts     # 疎通確認テスト（3件）
+│   ├── package.json         # Express 4, cors, ts-node-dev, knex, pg, mysql2
+│   ├── vitest.config.ts     # Vitestユニットテスト設定
+│   └── src/
+│       ├── index.ts         # GET /api/health + /api/schema, グレースフルシャットダウン
+│       ├── routes/schema.ts # GET /api/schema ルート
+│       └── services/
+│           ├── database.ts  # knexシングルトンファクトリ + executeQuery()
+│           ├── schema.ts    # INFORMATION_SCHEMAスキーマ取得
+│           └── sqlValidator.ts  # SQLバリデーター（SELECT以外を拒否）
+├── test/
+│   ├── e2e/app.spec.ts          # 疎通確認テスト（3件）
+│   └── unit/
+│       ├── schema.test.ts       # スキーマサービスユニットテスト（11件）
+│       └── sqlValidator.test.ts # SQLバリデーターユニットテスト（27件）
 ```
 
 ## ビルド・起動方法
@@ -35,6 +46,7 @@ output_system/
 ```bash
 # .envファイルの準備（初回のみ）
 cp output_system/.env.example output_system/.env
+# .envに DB_TYPE, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME を設定
 
 # 起動（output_system/ で実行）
 cd output_system
@@ -44,6 +56,10 @@ docker compose up -d
 # 確認
 docker compose ps
 curl http://localhost:3002/api/health  # または コンテナIP使用
+curl http://localhost:3002/api/schema  # DBスキーマ取得（DB設定済みの場合）
+
+# ユニットテスト（output_system/backend/ で実行）
+cd output_system/backend && npm test
 
 # E2Eテスト（AI Agent container上で実行）
 cd output_system
@@ -56,6 +72,12 @@ npx playwright test test/e2e/app.spec.ts
 - **concurrently**: 単一コンテナで複数プロセス起動のためconcurrentlyを採用。supervisordやforemanは過剰のため不採用
 - **vite preview**: DockerコンテナではViteのdevモードではなくbuildしてpreviewサーブ。devモードはHMRのWebSocket接続が必要でコンテナ環境と相性が悪い場合があるため
 - **CORS設定**: フロント（3001）とバックエンド（3002）のオリジンが異なるため明示的にCORS設定が必要
+- **knex DB_TYPE→クライアント変換**: `postgresql` → `pg`、`mysql` → `mysql2`。knex本体の `client` は `pg` / `mysql2` という文字列で指定する
+- **MySQL raw() の返り値**: `knex.raw()` はPostgreSQLでは `{ rows: [...] }` を返すが、MySQLでは `[rows, fields]` のタプルを返す。DB種別ごとに異なるデストラクチャリングが必要
+- **Vitest設定のincludeパス**: backendの `vitest.config.ts` から `../test/unit/**/*.test.ts` と相対パスで指定する（output_system/test/unit/ を参照）
+- **SQLバリデーターの設計**: 正規表現パーサーではなくキーワードリスト+単語境界(\b)方式を採用。node-sql-parserは複雑すぎるため不採用。単語境界を使うことで `created_at`→`CREATE` の誤検知を防止
+- **コメント除去の必要性**: `/* DROP TABLE users */ SELECT 1` のようなコメントインジェクション攻撃を防ぐため、キーワード検査前にコメント（--//* */）を除去してから検査する
+- **SqlValidationError**: `instanceof` で判別できるカスタムエラークラス。上位ルーターで400/500の振り分けに使用する
 
 ## はまりポイント
 
@@ -65,3 +87,5 @@ npx playwright test test/e2e/app.spec.ts
 ## 実装済み機能
 
 - PBI #5: Docker Composeで雛形アプリを起動できる（frontend/backend一括起動、ヘルスチェックAPI、E2Eテスト）
+- PBI #6: ユーザーDB(PostgreSQL/MySQL)へ接続確認できる（knex抽象化、GET /api/schema、INFORMATION_SCHEMAスキーマ取得、ユニットテスト）
+- PBI #7: SELECTのみ実行可能な安全なSQL実行基盤（sqlValidator.ts、database.executeQuery()、二重防御、ユニットテスト27件）

--- a/output_system/backend/src/services/database.ts
+++ b/output_system/backend/src/services/database.ts
@@ -18,6 +18,7 @@
  */
 
 import Knex, { Knex as KnexType } from 'knex'
+import { validate } from './sqlValidator'
 
 /** サポートするDBタイプ */
 export type DbType = 'postgresql' | 'mysql'
@@ -148,4 +149,181 @@ export async function closeDb(): Promise<void> {
  */
 export function resetDbInstance(instance: KnexType | null = null): void {
   dbInstance = instance
+}
+
+// -------------------------------------------------------------------
+// クエリ実行
+// -------------------------------------------------------------------
+
+/**
+ * クエリ実行結果の型
+ *
+ * SELECT 結果を JSON シリアライズ可能な形式に正規化して返す。
+ * グラフ・テーブル描画コンポーネントがそのまま利用できる形式とする。
+ */
+export interface QueryResult {
+  /**
+   * カラム名の配列（SELECTした列の順番を保持）
+   * 例: ['id', 'name', 'amount']
+   */
+  columns: string[]
+  /**
+   * データ行の配列。各行はカラム名をキーとした Record。
+   * BigInt や Date などの JSON 非対応型は文字列に変換済み。
+   * 例: [{ id: 1, name: 'Alice', amount: '1000.00' }]
+   */
+  rows: Record<string, unknown>[]
+}
+
+/**
+ * SELECT SQL文を実行し、結果を正規化した QueryResult で返す
+ *
+ * セキュリティ二重防御:
+ *   1. sqlValidator.validate() でSQL文の安全性を確認（第1層）
+ *   2. 実行直前にも validate() を呼び、バリデーションを確実に通過させる（第2層）
+ *
+ * 型変換:
+ *   - BigInt → String（例: 10000000000n → "10000000000"）
+ *   - Date → ISO 8601 文字列（例: 2024-01-01T00:00:00.000Z）
+ *   - null/undefined → null
+ *   - その他はそのまま返す
+ *
+ * エラーハンドリング:
+ *   - バリデーション失敗時は SqlValidationError をスロー
+ *   - DB接続エラーや実行エラーはそのまま上位に伝播
+ *
+ * @param sql - 実行する SQL 文字列
+ * @param db - 省略可能なknexインスタンス（省略時はシングルトンを使用、テスト用モック注入に利用）
+ * @returns QueryResult - { columns: string[], rows: Record<string, unknown>[] }
+ * @throws SqlValidationError - SQL がバリデーションを通過しなかった場合
+ * @throws Error - DB 接続やクエリ実行に失敗した場合
+ *
+ * @example
+ * ```typescript
+ * // 正常系: SELECT文の実行
+ * const result = await executeQuery('SELECT id, name FROM users LIMIT 10')
+ * console.log(result.columns) // ['id', 'name']
+ * console.log(result.rows)    // [{ id: 1, name: 'Alice' }, ...]
+ *
+ * // 異常系: INSERT文は拒否される
+ * await executeQuery("INSERT INTO users VALUES (1, 'Alice')")
+ * // => throws SqlValidationError: 'INSERT' キーワードを含むSQLは実行できません
+ * ```
+ */
+export async function executeQuery(
+  sql: string,
+  db?: KnexType
+): Promise<QueryResult> {
+  // 二重防御: 実行直前にも validate() を呼ぶ
+  // （呼び出し元が validate() を省略したケースでも確実にブロックする）
+  const validation = validate(sql)
+  if (!validation.ok) {
+    // バリデーション失敗: 詳細なエラーメッセージ付きの例外をスロー
+    throw new SqlValidationError(validation.reason ?? '不正なSQLです。')
+  }
+
+  // DBインスタンスを取得（テスト用モックか、シングルトン）
+  const knex = db ?? getDb()
+
+  // DB_TYPE を取得してクエリ実行方式を分岐
+  const dbType = process.env.DB_TYPE ?? 'postgresql'
+
+  // knex.raw() でバリデーション通過済み SQL を実行
+  // クエリ結果の形式は DB_TYPE によって異なる:
+  //   - PostgreSQL: { rows: [...], fields: [...] }
+  //   - MySQL:      [rows, fields] タプル
+  const rawResult = await knex.raw(sql)
+
+  let rawRows: Record<string, unknown>[]
+
+  if (dbType === 'mysql') {
+    // MySQL: knex.raw は [rows, fields] タプルを返す
+    rawRows = rawResult[0] as Record<string, unknown>[]
+  } else {
+    // PostgreSQL: knex.raw は { rows, fields } を返す
+    rawRows = rawResult.rows as Record<string, unknown>[]
+  }
+
+  // カラム名を最初の行から取得（結果が空でも空配列を返す）
+  const columns = rawRows.length > 0 ? Object.keys(rawRows[0]) : []
+
+  // 各行の値を JSON シリアライズ可能な形式に正規化する
+  const rows = rawRows.map((row) => normalizeRow(row))
+
+  return { columns, rows }
+}
+
+/**
+ * クエリ結果の1行を JSON シリアライズ可能な値に正規化する
+ *
+ * BigInt や Date は JSON.stringify() で正しく変換されないため、
+ * 文字列に変換してフロントエンドへ安全に渡せるようにする。
+ *
+ * @param row - knex.raw から返された1行のデータ
+ * @returns 各値を文字列・数値・真偽値・null に正規化した行データ
+ */
+function normalizeRow(row: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    normalized[key] = normalizeValue(value)
+  }
+  return normalized
+}
+
+/**
+ * 単一の値を JSON シリアライズ可能な形式に変換する
+ *
+ * @param value - 変換する値
+ * @returns JSON シリアライズ可能な値
+ */
+function normalizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    // null/undefined はそのまま null として返す
+    return null
+  }
+  if (typeof value === 'bigint') {
+    // BigInt は JSON 非対応のため文字列に変換
+    // 例: 10000000000n → "10000000000"
+    return value.toString()
+  }
+  if (value instanceof Date) {
+    // Date オブジェクトは ISO 8601 文字列に変換
+    // 例: 2024-01-01T00:00:00.000Z
+    return value.toISOString()
+  }
+  // その他の型（string, number, boolean 等）はそのまま返す
+  return value
+}
+
+/**
+ * SQLバリデーションエラー
+ *
+ * executeQuery() が不正なSQL（SELECT以外）を受け取ったときにスローされる。
+ * 上位のエラーハンドラーでこの型を判別し、適切なHTTPレスポンス（400等）を返す。
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await executeQuery('DROP TABLE users')
+ * } catch (err) {
+ *   if (err instanceof SqlValidationError) {
+ *     // 400 Bad Request
+ *     res.status(400).json({ error: err.message })
+ *   } else {
+ *     // 500 Internal Server Error
+ *     res.status(500).json({ error: 'DB error' })
+ *   }
+ * }
+ * ```
+ */
+export class SqlValidationError extends Error {
+  /** エラー種別を識別するためのタグ */
+  readonly type = 'SqlValidationError' as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'SqlValidationError'
+    // instanceof チェックが正しく動作するよう prototype を明示設定
+    Object.setPrototypeOf(this, SqlValidationError.prototype)
+  }
 }

--- a/output_system/backend/src/services/database.ts
+++ b/output_system/backend/src/services/database.ts
@@ -228,11 +228,21 @@ export async function executeQuery(
   // DB_TYPE を取得してクエリ実行方式を分岐
   const dbType = process.env.DB_TYPE ?? 'postgresql'
 
-  // knex.raw() でバリデーション通過済み SQL を実行
+  // sanitizedSql（コメント除去・正規化済み SQL）を DB に渡す
+  //
+  // セキュリティ上の根拠 (H1対策):
+  //   removeComments() は /*!50000 ... */ をブロックコメントとして除去するが、
+  //   元の SQL（コメント付き）を knex.raw() に渡すと MySQL エンジンが
+  //   条件付きコメント内のコードを実行してしまう設計上の乖離が生じる。
+  //   validate() が返す sanitizedSql（コメント除去後の SQL）を使用することで
+  //   この乖離を根本的に解消する。
+  const sqlToExecute = validation.sanitizedSql ?? sql
+
+  // knex.raw() でバリデーション・サニタイズ済み SQL を実行
   // クエリ結果の形式は DB_TYPE によって異なる:
   //   - PostgreSQL: { rows: [...], fields: [...] }
   //   - MySQL:      [rows, fields] タプル
-  const rawResult = await knex.raw(sql)
+  const rawResult = await knex.raw(sqlToExecute)
 
   let rawRows: Record<string, unknown>[]
 

--- a/output_system/backend/src/services/sqlValidator.ts
+++ b/output_system/backend/src/services/sqlValidator.ts
@@ -33,6 +33,19 @@ export interface ValidationResult {
    * ok が true のときは undefined。
    */
   reason?: string
+  /**
+   * ok が true のとき、コメント除去・正規化済みの SQL 文字列。
+   * executeQuery() はこの値を DB に渡すことで、MySQL 条件付きコメント
+   * （MySQL条件付きコメント形式など）バイパスを根本的に防止する。
+   *
+   * セキュリティ背景:
+   *   removeComments() はブロックコメントとして条件付きコメントを除去するが、
+   *   MySQL エンジンは条件付きコメント内のコードを実行する。
+   *   コメント除去後の SQL をそのまま DB へ渡すことで設計上の乖離を解消する。
+   *
+   * ok が false のときは undefined。
+   */
+  sanitizedSql?: string
 }
 
 /**
@@ -59,6 +72,18 @@ const FORBIDDEN_KEYWORDS: ReadonlyArray<string> = [
   'LOAD',
   'IMPORT',
   'COPY',
+  /**
+   * INTO を禁止キーワードに追加（H2対策）
+   *
+   * 以下の危険な構文をブロックするために必要:
+   *   - PostgreSQL: SELECT ... INTO table_name  （テーブル作成）
+   *   - MySQL:      SELECT ... INTO OUTFILE '/path'  （ファイル書き込み）
+   *
+   * 単語境界（\b）により以下への誤検知は発生しない:
+   *   - INFORMATION_SCHEMA（INFORMATIONの部分一致）
+   *   - INNER JOIN（単語 INNER の中にはINTOは含まれない）
+   */
+  'INTO',
 ]
 
 /**
@@ -249,5 +274,7 @@ export function validate(sql: string): ValidationResult {
   }
 
   // すべてのチェックを通過: 実行許可
-  return { ok: true }
+  // sanitizedSql にコメント除去・正規化済み SQL を格納する
+  // executeQuery() がこの値を DB へ渡すことで、MySQL 条件付きコメントバイパスを防止する
+  return { ok: true, sanitizedSql: normalized }
 }

--- a/output_system/backend/src/services/sqlValidator.ts
+++ b/output_system/backend/src/services/sqlValidator.ts
@@ -1,0 +1,228 @@
+/**
+ * SQLバリデーターサービス
+ *
+ * LLMが生成したSQL文をDataAgentが実行する前にバリデーションし、
+ * SELECT 文（および CTE を使った WITH 句）のみを許可する。
+ *
+ * セキュリティ設計方針（二重防御）:
+ *   1. このバリデーター（第1層）: 実行前に構文レベルでチェック
+ *   2. database.executeQuery（第2層）: 実行直前にも再チェック
+ *
+ * 許可する構文:
+ *   - SELECT ...
+ *   - WITH ... AS (...) SELECT ...   （CTE）
+ *
+ * 拒否する構文（代表例）:
+ *   - DML: INSERT / UPDATE / DELETE / MERGE
+ *   - DDL: CREATE / DROP / ALTER / TRUNCATE
+ *   - DCL: GRANT / REVOKE
+ *   - 複数ステートメント: SELECT 1; SELECT 2  （セミコロン区切り）
+ *   - コメント内に隠された危険キーワード
+ *
+ * 参考:
+ *   - OWASP SQL Injection Prevention: https://owasp.org/www-community/attacks/SQL_Injection
+ *   - ai_generated/requirements/README.md Security分析
+ */
+
+/** バリデーション結果 */
+export interface ValidationResult {
+  /** true: 実行許可, false: 実行拒否 */
+  ok: boolean
+  /**
+   * ok が false のときに拒否理由を説明するメッセージ。
+   * ok が true のときは undefined。
+   */
+  reason?: string
+}
+
+/**
+ * 禁止キーワードのリスト（大文字で統一。比較時は入力を大文字化）
+ *
+ * 正規表現ではなく文字列リストにすることで、将来の追加・削除を容易にする。
+ * キーワードは「単語境界」で検索するため、カラム名への誤検知を防ぐ。
+ */
+const FORBIDDEN_KEYWORDS: ReadonlyArray<string> = [
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'DROP',
+  'ALTER',
+  'TRUNCATE',
+  'CREATE',
+  'GRANT',
+  'REVOKE',
+  'MERGE',
+  'REPLACE',
+  'CALL',
+  'EXECUTE',
+  'EXEC',
+  'LOAD',
+  'IMPORT',
+  'COPY',
+]
+
+/**
+ * SQL 文字列からコメントを除去する
+ *
+ * コメント内に `DROP TABLE users` のような危険なキーワードを隠す
+ * コメントインジェクション攻撃を防ぐため、検査前にコメントを除去する。
+ *
+ * 対応するコメント形式:
+ *   - 行コメント: `-- ...` から行末まで
+ *   - ブロックコメント: `/* ... *‌/`（ネスト非対応）
+ *
+ * @param sql - 元の SQL 文字列
+ * @returns コメントを除去した SQL 文字列
+ */
+export function removeComments(sql: string): string {
+  // ブロックコメントを除去: /* ... */（改行を含む）
+  let result = sql.replace(/\/\*[\s\S]*?\*\//g, ' ')
+  // 行コメントを除去: -- から行末まで
+  result = result.replace(/--[^\r\n]*/g, ' ')
+  return result
+}
+
+/**
+ * 空白・改行を正規化する
+ *
+ * 連続する空白・タブ・改行を単一スペースに変換し、
+ * 前後の空白をトリムする。
+ *
+ * @param sql - SQL 文字列
+ * @returns 正規化した SQL 文字列
+ */
+function normalizeWhitespace(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * SQL 文字列に禁止キーワードが含まれているかチェックする
+ *
+ * 単語境界（\b）を使い、識別子名の一部として含まれるケース
+ * （例: `created_at` に `CREATE` が含まれる）は除外する。
+ *
+ * @param upperSql - 大文字化・コメント除去済みの SQL 文字列
+ * @returns 見つかった禁止キーワード、なければ null
+ */
+function findForbiddenKeyword(upperSql: string): string | null {
+  for (const keyword of FORBIDDEN_KEYWORDS) {
+    // \b（単語境界）で囲むことで、カラム名・テーブル名への誤マッチを防ぐ
+    const pattern = new RegExp(`\\b${keyword}\\b`)
+    if (pattern.test(upperSql)) {
+      return keyword
+    }
+  }
+  return null
+}
+
+/**
+ * 複数ステートメントが含まれていないかチェックする
+ *
+ * セミコロン（;）で区切られた複数のステートメントは、
+ * SQLインジェクションの典型的な手法（Stacked Queries）であるため拒否する。
+ *
+ * 許容するケース:
+ *   - SQL末尾の1個のセミコロン（例: `SELECT 1;`）
+ *
+ * @param sql - 正規化済みの SQL 文字列
+ * @returns 複数ステートメントが含まれていれば true
+ */
+function hasMultipleStatements(sql: string): boolean {
+  // 末尾のセミコロンを除去してから、残りにセミコロンが含まれるか確認
+  const withoutTrailingSemicolon = sql.replace(/;\s*$/, '')
+  return withoutTrailingSemicolon.includes(';')
+}
+
+/**
+ * SQL 文が SELECT または WITH で始まるかチェックする
+ *
+ * 許可する開始キーワード:
+ *   - SELECT: 通常のクエリ
+ *   - WITH: CTE（Common Table Expressions）を使ったクエリ
+ *
+ * @param upperSql - 大文字化・正規化済みの SQL 文字列
+ * @returns 許可されている開始キーワードなら true
+ */
+function startsWithAllowedKeyword(upperSql: string): boolean {
+  return /^\s*(SELECT|WITH)\b/.test(upperSql)
+}
+
+/**
+ * SQL 文をバリデーションし、実行可否を返す
+ *
+ * 以下の順序でチェックを行う:
+ *   1. 空文字チェック
+ *   2. コメント除去
+ *   3. 複数ステートメントチェック
+ *   4. 禁止キーワードチェック
+ *   5. 許可キーワードで始まるかチェック
+ *
+ * @param sql - バリデーション対象の SQL 文字列
+ * @returns ValidationResult - ok: true なら実行可、false なら reason に拒否理由
+ *
+ * @example
+ * ```typescript
+ * // 許可されるケース
+ * validate('SELECT * FROM users')
+ * // => { ok: true }
+ *
+ * validate('WITH cte AS (SELECT id FROM users) SELECT * FROM cte')
+ * // => { ok: true }
+ *
+ * // 拒否されるケース
+ * validate('INSERT INTO users VALUES (1)')
+ * // => { ok: false, reason: '...' }
+ *
+ * validate('SELECT 1; DROP TABLE users')
+ * // => { ok: false, reason: '...' }
+ * ```
+ */
+export function validate(sql: string): ValidationResult {
+  // チェック 1: 空文字・空白のみ
+  if (!sql || !sql.trim()) {
+    return {
+      ok: false,
+      reason: 'SQLが空です。SELECT文を入力してください。',
+    }
+  }
+
+  // チェック 2: コメントを除去してから以降の検査を行う
+  // コメント内に危険キーワードを隠す攻撃（例: /* DROP TABLE users */ SELECT 1）を防ぐ
+  const withoutComments = removeComments(sql)
+  const normalized = normalizeWhitespace(withoutComments)
+
+  // チェック 3: 複数ステートメント（Stacked Queries）の検出
+  // 例: SELECT 1; DELETE FROM users
+  if (hasMultipleStatements(normalized)) {
+    return {
+      ok: false,
+      reason:
+        '複数のSQL文（セミコロン区切り）は許可されていません。1つのSELECT文のみ入力してください。',
+    }
+  }
+
+  // 大文字化して以降のキーワード検索を統一する
+  const upperSql = normalized.toUpperCase()
+
+  // チェック 4: 禁止キーワードの検出
+  // INSERT / UPDATE / DELETE / DROP / ALTER / TRUNCATE 等が含まれていないか確認
+  const foundKeyword = findForbiddenKeyword(upperSql)
+  if (foundKeyword !== null) {
+    return {
+      ok: false,
+      reason: `'${foundKeyword}' キーワードを含むSQLは実行できません。SELECTクエリのみ許可されています。`,
+    }
+  }
+
+  // チェック 5: 許可キーワード（SELECT / WITH）で始まるか確認
+  if (!startsWithAllowedKeyword(upperSql)) {
+    return {
+      ok: false,
+      reason:
+        'SELECTまたはWITHで始まるSQL文のみ許可されています。',
+    }
+  }
+
+  // すべてのチェックを通過: 実行許可
+  return { ok: true }
+}

--- a/output_system/backend/src/services/sqlValidator.ts
+++ b/output_system/backend/src/services/sqlValidator.ts
@@ -71,12 +71,25 @@ const FORBIDDEN_KEYWORDS: ReadonlyArray<string> = [
  *   - 行コメント: `-- ...` から行末まで
  *   - ブロックコメント: `/* ... *‌/`（ネスト非対応）
  *
+ * ネストしたブロックコメントのバイパス対策:
+ *   "/* /* DROP *" + "/ *" + "/" のように内側コメントを除去した後に外側の閉じタグが残る場合、
+ *   その残留閉じタグもバイパス手段となるため追加で除去する。
+ *   例: ネストコメント → 最短一致で内側除去 → 外側が残る → ループ除去 → 残留閉じタグ除去
+ *
  * @param sql - 元の SQL 文字列
  * @returns コメントを除去した SQL 文字列
  */
 export function removeComments(sql: string): string {
   // ブロックコメントを除去: /* ... */（改行を含む）
-  let result = sql.replace(/\/\*[\s\S]*?\*\//g, ' ')
+  // ネストしたコメントに対応するため、コメントがなくなるまで繰り返し除去する
+  let result = sql
+  let previous: string
+  do {
+    previous = result
+    result = result.replace(/\/\*[\s\S]*?\*\//g, ' ')
+  } while (result !== previous)
+  // ネストしたコメント除去後に残留する可能性のある */ を除去（バイパス防止）
+  result = result.replace(/\*\//g, ' ')
   // 行コメントを除去: -- から行末まで
   result = result.replace(/--[^\r\n]*/g, ' ')
   return result
@@ -123,13 +136,25 @@ function findForbiddenKeyword(upperSql: string): string | null {
  *
  * 許容するケース:
  *   - SQL末尾の1個のセミコロン（例: `SELECT 1;`）
+ *   - 文字列リテラル内のセミコロン（例: `WHERE message = 'error; warning'`）
+ *
+ * 文字列リテラル除外の設計:
+ *   シングルクォート（'...'）またはダブルクォート（"..."）で囲まれた文字列内の
+ *   セミコロンはリテラル値の一部であり、ステートメント区切りとして解釈しない。
+ *   これにより `WHERE message = 'error; warning'` のような正常クエリを誤拒否しない。
  *
  * @param sql - 正規化済みの SQL 文字列
  * @returns 複数ステートメントが含まれていれば true
  */
 function hasMultipleStatements(sql: string): boolean {
+  // 文字列リテラル（シングルクォート・ダブルクォート）内のセミコロンは
+  // ステートメント区切りではないため、リテラル部分を空文字で置換してからチェックする
+  // ※ エスケープされたクォート（'' または \"）も考慮した最短一致マッチ
+  const withoutStringLiterals = sql
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
   // 末尾のセミコロンを除去してから、残りにセミコロンが含まれるか確認
-  const withoutTrailingSemicolon = sql.replace(/;\s*$/, '')
+  const withoutTrailingSemicolon = withoutStringLiterals.replace(/;\s*$/, '')
   return withoutTrailingSemicolon.includes(';')
 }
 

--- a/output_system/backend/vitest.config.ts
+++ b/output_system/backend/vitest.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      // カバレッジ対象: services/schema.ts のみ（Task 1.2.4 の完了条件）
-      include: ['src/services/schema.ts'],
+      // カバレッジ対象: services/ 配下のサービスファイル
+      // Task 1.2.4: schema.ts, Task 2.1.1: sqlValidator.ts を含む
+      include: ['src/services/schema.ts', 'src/services/sqlValidator.ts'],
       reporter: ['text', 'json', 'html'],
       // 80%以上のカバレッジを要求
       thresholds: {

--- a/output_system/test/unit/sqlValidator.test.ts
+++ b/output_system/test/unit/sqlValidator.test.ts
@@ -1,0 +1,374 @@
+/**
+ * 【モジュール】backend/src/services/sqlValidator.ts
+ * SQLバリデーターサービスのユニットテスト
+ *
+ * このファイルでは SQLバリデーターの以下の挙動を検証する:
+ * - 許可パターン: SELECT文, JOINを含むSELECT, サブクエリ, CTE(WITH句)
+ * - 拒否パターン: INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE 等の変更系SQL
+ * - 拒否パターン: 複数ステートメント（セミコロン区切り）
+ * - 拒否パターン: コメント内に隠された危険キーワード
+ * - 境界ケース: 空文字, 空白のみ, セミコロンのみ
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validate, removeComments } from '../../backend/src/services/sqlValidator'
+
+/**
+ * 【モジュール】removeComments
+ * コメント除去の純粋関数テスト
+ */
+describe('removeComments', () => {
+  /**
+   * 【テスト対象】removeComments
+   * 【テスト内容】行コメント（-- ...）を含む SQL を渡した場合
+   * 【期待結果】行コメント部分が除去されること
+   */
+  it('should remove line comments (--)', () => {
+    const sql = 'SELECT * FROM users -- get all users'
+    const result = removeComments(sql)
+    expect(result).not.toContain('--')
+    expect(result).toContain('SELECT * FROM users')
+  })
+
+  /**
+   * 【テスト対象】removeComments
+   * 【テスト内容】ブロックコメント（/* ... *‌/）を含む SQL を渡した場合
+   * 【期待結果】ブロックコメント部分が除去されること
+   */
+  it('should remove block comments (/* ... */)', () => {
+    const sql = 'SELECT /* this is a comment */ * FROM users'
+    const result = removeComments(sql)
+    expect(result).not.toContain('this is a comment')
+    expect(result).toContain('SELECT')
+    expect(result).toContain('FROM users')
+  })
+
+  /**
+   * 【テスト対象】removeComments
+   * 【テスト内容】複数行ブロックコメントを含む SQL を渡した場合
+   * 【期待結果】改行を含むブロックコメントが除去されること
+   */
+  it('should remove multiline block comments', () => {
+    const sql = `SELECT *
+/*
+  multiline
+  comment
+*/
+FROM users`
+    const result = removeComments(sql)
+    expect(result).not.toContain('multiline')
+    expect(result).not.toContain('comment')
+    expect(result).toContain('SELECT')
+    expect(result).toContain('FROM users')
+  })
+})
+
+/**
+ * 【モジュール】validate
+ * SQLバリデーション関数の包括的テスト
+ */
+describe('validate', () => {
+  // -------------------------------------------------------------------
+  // 許可パターン
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】単純な SELECT * FROM テーブル を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow a simple SELECT statement', () => {
+    const result = validate('SELECT * FROM users')
+    expect(result.ok).toBe(true)
+    expect(result.reason).toBeUndefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】WHERE句付きの SELECT を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow SELECT with WHERE clause', () => {
+    const result = validate("SELECT id, name FROM users WHERE active = 1")
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】JOIN を含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow SELECT with JOIN', () => {
+    const result = validate(
+      'SELECT u.id, u.name, o.total FROM users u INNER JOIN orders o ON u.id = o.user_id'
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】サブクエリを含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow SELECT with subquery', () => {
+    const result = validate(
+      'SELECT * FROM orders WHERE user_id IN (SELECT id FROM users WHERE active = 1)'
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】CTE（WITH句）を含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow SELECT with CTE (WITH clause)', () => {
+    const result = validate(
+      'WITH active_users AS (SELECT id, name FROM users WHERE active = 1) SELECT * FROM active_users'
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】末尾にセミコロンが1つある SELECT を渡した場合
+   * 【期待結果】ok: true が返ること（末尾の単一セミコロンは許容）
+   */
+  it('should allow SELECT with a single trailing semicolon', () => {
+    const result = validate('SELECT * FROM users;')
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】小文字の select を含む SQL を渡した場合
+   * 【期待結果】ok: true が返ること（大文字小文字を区別しない）
+   */
+  it('should allow lowercase select keyword', () => {
+    const result = validate('select * from users')
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】aggregate関数（COUNT, SUM等）を含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow SELECT with aggregate functions', () => {
+    const result = validate(
+      'SELECT COUNT(*), SUM(amount), AVG(amount) FROM orders GROUP BY user_id HAVING COUNT(*) > 1'
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  // -------------------------------------------------------------------
+  // 拒否パターン: DML
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】INSERT INTO を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject INSERT statement', () => {
+    const result = validate("INSERT INTO users (name) VALUES ('Alice')")
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('INSERT')
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】UPDATE を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject UPDATE statement', () => {
+    const result = validate("UPDATE users SET name = 'Bob' WHERE id = 1")
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('UPDATE')
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】DELETE FROM を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject DELETE statement', () => {
+    const result = validate('DELETE FROM users WHERE id = 1')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('DELETE')
+  })
+
+  // -------------------------------------------------------------------
+  // 拒否パターン: DDL
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】DROP TABLE を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject DROP TABLE statement', () => {
+    const result = validate('DROP TABLE users')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('DROP')
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】ALTER TABLE を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject ALTER TABLE statement', () => {
+    const result = validate('ALTER TABLE users ADD COLUMN age INT')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('ALTER')
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】TRUNCATE TABLE を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject TRUNCATE TABLE statement', () => {
+    const result = validate('TRUNCATE TABLE users')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('TRUNCATE')
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】CREATE TABLE を含む SQL を渡した場合
+   * 【期待結果】ok: false が返り、reason に拒否理由が含まれること
+   */
+  it('should reject CREATE TABLE statement', () => {
+    const result = validate('CREATE TABLE new_table (id INT)')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('CREATE')
+  })
+
+  // -------------------------------------------------------------------
+  // 拒否パターン: 複数ステートメント（Stacked Queries）
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】セミコロンで区切られた複数のSELECT文を渡した場合
+   * 【期待結果】ok: false が返ること（Stacked Queries の防止）
+   */
+  it('should reject multiple statements separated by semicolon', () => {
+    const result = validate('SELECT 1; SELECT 2')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】SELECT の後に DROP を含む複数ステートメントを渡した場合
+   * 【期待結果】ok: false が返ること（SQLインジェクション典型パターンの防止）
+   */
+  it('should reject SELECT followed by DROP via semicolon', () => {
+    const result = validate('SELECT * FROM users; DROP TABLE users')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // -------------------------------------------------------------------
+  // 拒否パターン: コメント内の危険キーワード
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】ブロックコメント内に DROP を含む SQL を渡した場合
+   * 【期待結果】コメント除去後にSELECTで始まれば ok: true（コメント内のキーワードは無視される）
+   *
+   * 補足: コメントは除去されてから検査するため、コメント内の DROP は無視される。
+   * 実際に危険なのは「コメント外」に危険キーワードが来る場合のみ。
+   */
+  it('should ignore dangerous keywords inside block comments', () => {
+    // コメント内の DROP は除去されるため、実際は SELECT だけが残る → 許可
+    const result = validate('SELECT /* DROP TABLE users */ * FROM users')
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】行コメントの後にDROPを含む SQL を渡した場合
+   * 【期待結果】コメント除去後にDROPが残れば ok: false
+   *
+   * 補足: コメントの後に改行で別の文が続く場合は、コメント外なので拒否される。
+   */
+  it('should reject dangerous keywords outside comments', () => {
+    // コメントの後に改行で DROP が来る場合はコメント外なので拒否
+    const result = validate('SELECT 1\n-- comment\nDROP TABLE users')
+    expect(result.ok).toBe(false)
+  })
+
+  // -------------------------------------------------------------------
+  // 境界ケース
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - 境界ケース
+   * 【テスト内容】空文字を渡した場合
+   * 【期待結果】ok: false が返り、reason が設定されること
+   */
+  it('should reject empty string', () => {
+    const result = validate('')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 境界ケース
+   * 【テスト内容】空白のみの文字列を渡した場合
+   * 【期待結果】ok: false が返ること
+   */
+  it('should reject whitespace-only string', () => {
+    const result = validate('   \t\n  ')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 境界ケース
+   * 【テスト内容】セミコロンのみの文字列を渡した場合
+   * 【期待結果】ok: false が返ること（SELECT で始まっていないため）
+   */
+  it('should reject semicolon-only string', () => {
+    const result = validate(';')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 境界ケース
+   * 【テスト内容】SELECTで始まらない任意の文字列（例: SHOW TABLES）を渡した場合
+   * 【期待結果】ok: false が返ること
+   */
+  it('should reject SQL not starting with SELECT or WITH', () => {
+    const result = validate('SHOW TABLES')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  /**
+   * 【テスト対象】validate - 境界ケース
+   * 【テスト内容】カラム名に "created_at" のように CREATED を含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること（単語境界チェックにより誤検知しないこと）
+   *
+   * 補足: CREATE は禁止キーワードだが、CREATED_AT はカラム名のため許可される。
+   * \b（単語境界）により識別子内部の部分一致は無視される。
+   */
+  it('should allow SELECT with column name containing forbidden keyword as substring', () => {
+    // created_at は CREATE を含むが、単語境界で分離されているため許可される
+    const result = validate('SELECT id, created_at, updated_at FROM users')
+    expect(result.ok).toBe(true)
+  })
+})

--- a/output_system/test/unit/sqlValidator.test.ts
+++ b/output_system/test/unit/sqlValidator.test.ts
@@ -61,6 +61,24 @@ FROM users`
     expect(result).toContain('SELECT')
     expect(result).toContain('FROM users')
   })
+
+  /**
+   * 【テスト対象】removeComments
+   * 【テスト内容】ネストしたブロックコメントを渡した場合
+   * 【期待結果】内側コメント除去後に残留する外側の閉じタグも除去されること
+   *
+   * バイパス防止:
+   *   最短一致で内側コメントを除去すると外側の閉じタグが残り、
+   *   後続のキーワード検査をバイパスされる恐れがある。
+   *   残留する閉じタグを追加除去することでバイパスを防ぐ。
+   */
+  it('should remove residual block comment close tag from nested block comments', () => {
+    // ネストコメント: 内側除去後に外側の閉じタグが残らないことを確認
+    const sql = '/* /* DROP */ */ SELECT 1'
+    const result = removeComments(sql)
+    expect(result).not.toContain('*/')
+    expect(result).not.toContain('DROP')
+  })
 })
 
 /**
@@ -136,6 +154,23 @@ describe('validate', () => {
    */
   it('should allow SELECT with a single trailing semicolon', () => {
     const result = validate('SELECT * FROM users;')
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - 許可パターン
+   * 【テスト内容】文字列リテラル内にセミコロンを含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること（リテラル内セミコロンはステートメント区切りではない）
+   *
+   * 背景: hasMultipleStatements() が単純な includes(';') だと、
+   *   WHERE message = 'error; warning' のような正常クエリを誤拒否してしまう。
+   *   文字列リテラルを除外してからセミコロン検出することで誤拒否を防ぐ。
+   *
+   * 入力例:
+   *   SELECT * FROM logs WHERE message = 'error; warning'
+   */
+  it('should allow SELECT with semicolon inside string literal', () => {
+    const result = validate("SELECT * FROM logs WHERE message = 'error; warning'")
     expect(result.ok).toBe(true)
   })
 
@@ -307,6 +342,28 @@ describe('validate', () => {
   it('should reject dangerous keywords outside comments', () => {
     // コメントの後に改行で DROP が来る場合はコメント外なので拒否
     const result = validate('SELECT 1\n-- comment\nDROP TABLE users')
+    expect(result.ok).toBe(false)
+  })
+
+  /**
+   * 【テスト対象】validate - 拒否パターン
+   * 【テスト内容】ネストしたブロックコメントでキーワードを隠す SQL を渡した場合
+   * 【期待結果】ok: false が返ること（バイパス攻撃の防止）
+   *
+   * 攻撃パターン:
+   *   ネストしたブロックコメントを使うと、最短一致の正規表現は内側コメントのみを
+   *   除去し、外側の閉じタグが残留する。
+   *   残留した閉じタグの後に実際の SQL 文が続く場合、コメント除去が不完全となり
+   *   バイパスが成立する恐れがある。
+   *   removeComments でループ除去 + 残留閉じタグの除去により防止する。
+   *
+   * 入力例:
+   *   "/* /* DROP TABLE users *" + "/ *" + "/ DROP TABLE users"
+   *   → コメント除去後に DROP TABLE users が残れば ok: false になるべき
+   */
+  it('should reject nested block comment bypass attempt', () => {
+    // ネストコメントの外側に実際のDROPが存在するパターン
+    const result = validate('/* /* comment */ */ DROP TABLE users')
     expect(result.ok).toBe(false)
   })
 

--- a/output_system/test/unit/sqlValidator.test.ts
+++ b/output_system/test/unit/sqlValidator.test.ts
@@ -428,4 +428,143 @@ describe('validate', () => {
     const result = validate('SELECT id, created_at, updated_at FROM users')
     expect(result.ok).toBe(true)
   })
+
+  // -------------------------------------------------------------------
+  // [H1] MySQL条件付きコメントバイパス対策テスト
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - H1対策
+   * 【テスト内容】MySQL 条件付きコメント (/* !50000 DROP TABLE users * /) を渡した場合
+   * 【期待結果】ok: false が返ること（条件付きコメントをブロックコメントとして除去し、
+   *            DROP キーワードが残れば拒否）
+   *
+   * 攻撃パターン:
+   *   MySQL条件付きコメント内の DROP は、MySQL エンジンがコードとして実行する。
+   *   removeComments() がコメントとして除去するが、
+   *   その後コメント除去済み SQL（sanitizedSql）が DB に渡されることを保証する。
+   *
+   * 検証観点:
+   *   - validate() は ok: false を返すか、または ok: true の場合は
+   *     sanitizedSql から DROP が除去されていること（DBへは安全な SQL が渡る）
+   */
+  it('should handle MySQL conditional comment /*!50000 DROP TABLE users */ safely', () => {
+    const sql = '/*!50000 DROP TABLE users */'
+    const result = validate(sql)
+    if (result.ok) {
+      // ok: true になった場合は sanitizedSql に DROP が含まれていないことを保証する
+      // （DBには条件付きコメント除去済みの安全な SQL のみが渡される）
+      expect(result.sanitizedSql).toBeDefined()
+      expect(result.sanitizedSql!.toUpperCase()).not.toMatch(/\bDROP\b/)
+    } else {
+      // ok: false の場合は reason が設定されていること
+      expect(result.reason).toBeDefined()
+    }
+  })
+
+  /**
+   * 【テスト対象】validate - H1対策（sanitizedSql）
+   * 【テスト内容】許可されたSELECT文に対して sanitizedSql が返ること
+   * 【期待結果】ok: true かつ sanitizedSql がコメント除去・正規化済みであること
+   *
+   * セキュリティ保証:
+   *   executeQuery() は validation.sanitizedSql を DB へ渡すため、
+   *   元の SQL（コメント付き）は DB に到達しない。
+   */
+  it('should return sanitizedSql for valid SELECT statement', () => {
+    const sql = 'SELECT * FROM users -- get all'
+    const result = validate(sql)
+    expect(result.ok).toBe(true)
+    expect(result.sanitizedSql).toBeDefined()
+    // コメントが除去されていること
+    expect(result.sanitizedSql).not.toContain('--')
+    // SELECT 文が残っていること
+    expect(result.sanitizedSql!.toUpperCase()).toContain('SELECT')
+  })
+
+  /**
+   * 【テスト対象】validate - H1対策（MySQL 条件付きコメント + 有効なSELECT）
+   * 【テスト内容】SELECT の後に MySQL 条件付きコメントを含む SQL を渡した場合
+   * 【期待結果】sanitizedSql から条件付きコメント部分が除去されていること
+   *
+   * 例: SELECT [条件付きコメント 50000] * FROM users
+   *   → sanitizedSql: SELECT * FROM users（コメント内容は除去済み）
+   *
+   * MySQL エンジンへは条件付きコメント内のコードが渡らないため安全。
+   */
+  it('should strip MySQL conditional comment content from sanitizedSql', () => {
+    const sql = 'SELECT /*!50000 1 */ * FROM users'
+    const result = validate(sql)
+    expect(result.ok).toBe(true)
+    expect(result.sanitizedSql).toBeDefined()
+    // 条件付きコメントの内容（50000）が除去されていること
+    expect(result.sanitizedSql).not.toContain('50000')
+  })
+
+  // -------------------------------------------------------------------
+  // [H2] SELECT INTO バイパス対策テスト
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - H2対策
+   * 【テスト内容】PostgreSQL の SELECT ... INTO table_name（テーブル作成）を渡した場合
+   * 【期待結果】ok: false が返ること（INTO が禁止キーワードに含まれる）
+   *
+   * 攻撃パターン:
+   *   PostgreSQL: SELECT * INTO new_table FROM users
+   *   → new_table というテーブルが作成される（DDL相当）
+   */
+  it('should reject PostgreSQL SELECT INTO (table creation)', () => {
+    const result = validate('SELECT * INTO new_table FROM users')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('INTO')
+  })
+
+  /**
+   * 【テスト対象】validate - H2対策
+   * 【テスト内容】MySQL の SELECT ... INTO OUTFILE（ファイル書き込み）を渡した場合
+   * 【期待結果】ok: false が返ること（INTO が禁止キーワードに含まれる）
+   *
+   * 攻撃パターン:
+   *   MySQL: SELECT * INTO OUTFILE '/tmp/x' FROM users
+   *   → サーバー上のファイルにクエリ結果が書き込まれる（情報漏洩）
+   */
+  it('should reject MySQL SELECT INTO OUTFILE (file write)', () => {
+    const result = validate("SELECT * INTO OUTFILE '/tmp/x' FROM users")
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeDefined()
+    expect(result.reason).toContain('INTO')
+  })
+
+  // -------------------------------------------------------------------
+  // [H2] INTO の誤検知防止テスト
+  // -------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validate - H2誤検知防止
+   * 【テスト内容】INFORMATION_SCHEMA を参照する SELECT を渡した場合
+   * 【期待結果】ok: true が返ること（単語境界 \b により INFORMATION の中の INTO は無視）
+   *
+   * 補足: INFORMATION_SCHEMA は情報スキーマへの参照であり正常なクエリ。
+   * INTO キーワード検出では \b（単語境界）を使用するため誤検知しない。
+   */
+  it('should allow SELECT from INFORMATION_SCHEMA without false positive on INTO', () => {
+    const result = validate('SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = \'users\'')
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validate - H2誤検知防止
+   * 【テスト内容】INNER JOIN を含む SELECT を渡した場合
+   * 【期待結果】ok: true が返ること（単語 INNER に INTO は含まれないため誤検知しない）
+   *
+   * 補足: INNER JOIN は通常の結合構文。INTO 禁止は単語境界マッチのため影響しない。
+   */
+  it('should allow SELECT with INNER JOIN without false positive on INTO', () => {
+    const result = validate(
+      'SELECT a.id, b.name FROM table_a a INNER JOIN table_b b ON a.id = b.id'
+    )
+    expect(result.ok).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

LLMが生成したSQLがSELECT文のみ実行され、それ以外はブロックされる仕組みを実装した。
`sqlValidator` モジュールでSELECT以外を拒否し、`database.executeQuery()` でも実行直前に再チェックする二重防御を構築している。

### 実装内容

**親Epic**: #1 自然言語→SQL→実行

**対象PBI**: #7 PBI 2.1: 利用者がSELECTのみ実行可能な安全なSQL実行基盤を使える
- #24 Task 2.1.1: SQLValidatorサービスを実装しSELECT以外を拒否する ✅
- #25 Task 2.1.2: DB実行関数にSQLValidator二重チェックを組み込む ✅
- #26 Task 2.1.3: SQLValidatorのユニットテストを追加する ✅

### 変更ファイル

**新規作成**
- `output_system/backend/src/services/sqlValidator.ts` - SQLバリデーターサービス
  - `validate(sql): ValidationResult` - SELECT/WITH以外を拒否する検証関数
  - `removeComments(sql)` - コメントインジェクション対策のコメント除去
  - 禁止キーワード: INSERT/UPDATE/DELETE/DROP/ALTER/TRUNCATE/CREATE/GRANT/REVOKE等
- `output_system/test/unit/sqlValidator.test.ts` - ユニットテスト（27件）

**変更**
- `output_system/backend/src/services/database.ts` - `executeQuery()` を追加
  - バリデーション通過済みSQLのみ実行（二重防御の第2層）
  - `{columns, rows}` の QueryResult を返す
  - BigInt/Date をJSON シリアライズ可能な形式に変換
  - `SqlValidationError` クラスを定義
- `output_system/backend/vitest.config.ts` - カバレッジ対象に `sqlValidator.ts` を追加

## Test Plan

受入条件に基づくテスト:

- [x] `SELECT ...` クエリは許可される（単純SELECT/JOIN/サブクエリ/CTE/集計関数）
- [x] `INSERT/UPDATE/DELETE/DROP/ALTER/TRUNCATE` を含むクエリは拒否される
- [x] 複数ステートメント（`;` で連結されるマルチ文）は拒否される
- [x] バリデータ拒否時は明確なエラーメッセージを返す（SqlValidationError）
- [x] `database.executeQuery(sql)` はバリデータ通過済みSQLのみ実行する
- [x] ユニットテストで代表的OK/NGパターン（10件以上: 27件）を検証する
- [x] 空文字・空白のみ・セミコロンのみの境界ケースを検証する
- [x] コメント内のキーワードは除去後に検査（コメントインジェクション対策）
- [x] `created_at` 等の識別子名に禁止キーワードを含む場合は許可（誤検知防止）

## Related Issues

- Closes #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)