### PR TITLE
[PBI #146] SQLiteデータベースが起動時に自動初期化される 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -116,6 +116,7 @@ npx playwright test test/e2e/app.spec.ts
 - **DataTableの日付フォーマット**: ISO 8601パターン（YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss等）を正規表現で検出し、toLocaleDateString('ja-JP')でフォーマット。日付のみの場合はtimeZone: 'UTC'を指定してタイムゾーンのずれを防止
 - **コピー機能の実装**: Clipboard APIは`window.isSecureContext`が必要。HTTP環境（コンテナ名アクセス）では使えないため、execCommandフォールバックを用意した
 - **strict modeとPlaywright**: `page.locator()`は複数マッチするとstrict modeでエラーになる。`.first()`や`.filter()`で一意に絞ること
+- **db_connection_id のNULL許容設計**: SQLite本来のdb.md定義はNOT NULLだが、後続PBI（#147 DB接続先管理）が実装されるまでchat.ts側がdb_connection_idを知らないため暫定的にNULL許容とした。後続PBI実装時にNOT NULL化が必要
 
 ## はまりポイント
 
@@ -126,9 +127,11 @@ npx playwright test test/e2e/app.spec.ts
 - **vite preview にプロキシ機能なし**: `vite preview` は静的ファイルサービスのみ。`/api/xxx` の相対パスリクエストは同一オリジン（3001）に送られる。VITE_API_BASE_URL でバックエンドURLを明示するか、`vite.config.ts` の `preview.proxy` に `/api` を設定する
 - **better-sqlite3のNODE_MODULE_VERSION不一致**: Dockerビルド時、ホスト側でnpm installされた.nodeファイルがコンテナのNode.jsバージョンと合わない。`COPY output_system/ ./` の後に `RUN npm rebuild better-sqlite3` を実行すること
 - **E2EテストでSSEモックは実DBに書き込まない**: PlaywrightでGET /api/chatをモックしても実際のSQLiteには保存されない。GET /api/historyも合わせてモックしないと履歴が空のまま
+- **SQLite ALTER TABLEでのFK付きカラム追加不可**: SQLiteのALTER TABLE ADD COLUMNはFOREIGN KEY制約付きカラムを追加できない。テーブル再作成（DROP→CREATE）が必要。今回はdb.mdのマイグレーション方針（既存DB破棄許可）に従いDROP＆CREATE方式を採用
 
 ## 実装済み機能
 
+- PBI #145: Docker Composeでフロントエンド・バックエンドを一括起動できる（backend/src/config/index.ts・types/index.ts追加、.env.example にDB_ENCRYPTION_KEY追加）
 - PBI #5: Docker Composeで雛形アプリを起動できる（frontend/backend一括起動、ヘルスチェックAPI、E2Eテスト）
 - PBI #6: ユーザーDB(PostgreSQL/MySQL)へ接続確認できる（knex抽象化、GET /api/schema、INFORMATION_SCHEMAスキーマ取得、ユニットテスト）
 - PBI #7: SELECTのみ実行可能な安全なSQL実行基盤（sqlValidator.ts、database.executeQuery()、二重防御、ユニットテスト27件）
@@ -138,3 +141,4 @@ npx playwright test test/e2e/app.spec.ts
 - PBI #11: テーブル形式で結果を参照・スクロール閲覧できる（DataTable本格実装、縦横スクロール/sticky header/ゼブラストライプ/NULL表示/数値右寄せ/日付フォーマット/コピー機能、ユニットテスト14件・E2Eテスト8件）
 - PBI #12: 会話・メッセージがSQLiteに保存される（better-sqlite3、historyDb.ts、Repository Pattern、GET/DELETE /api/history、conversationイベント追加、125件ユニットテスト）
 - PBI #13: サイドバーから履歴を閲覧・選択・削除できる（useHistory.ts、Sidebar/HistoryItem.tsx実装、App.tsx統合、自動リフレッシュ、検索フィルタ、E2Eテスト7件）
+- PBI #146: SQLiteが起動時に自動初期化される（db_connectionsテーブル追加、conversations.db_connection_id FK追加、Repository関数追加、180件ユニットテスト全通過）

--- a/output_system/backend/src/services/historyDb.ts
+++ b/output_system/backend/src/services/historyDb.ts
@@ -1,12 +1,15 @@
 /**
  * 会話履歴用 SQLite データベース初期化・マイグレーションモジュール
  *
- * DataAgent の内部DB（クエリ履歴管理）を better-sqlite3 で管理する。
- * 外部ユーザーDBとは分離された専用DBで、会話・メッセージの永続化を担う。
+ * DataAgent の内部DB（DB接続先管理・クエリ履歴管理）を better-sqlite3 で管理する。
+ * 外部ユーザーDBとは分離された専用DBで、DB接続先・会話・メッセージの永続化を担う。
  *
  * テーブル構成 (db.md ER図準拠):
- *   conversations - 会話セッション（id, title, created_at, updated_at）
- *   messages      - 個別メッセージ（id, conversation_id, role, content, sql, chart_type, query_result, error, created_at）
+ *   db_connections - DB接続先管理（id, name, db_type, host, port, username, password_encrypted,
+ *                    database_name, is_last_used, created_at, updated_at）
+ *   conversations  - 会話セッション（id, db_connection_id FK, title, created_at, updated_at）
+ *   messages       - 個別メッセージ（id, conversation_id FK, role, content, sql, chart_type,
+ *                    query_result, error, analysis, created_at）
  *
  * 環境変数:
  *   HISTORY_DB_PATH : SQLite ファイルパス（デフォルト: /app/data/history.sqlite）
@@ -15,6 +18,13 @@
  *   - DBファイルは .gitignore 対象（data/ ディレクトリ除外）
  *   - Docker named volume でデータを永続化（docker-compose.yml 参照）
  *   - WAL モードで書き込みパフォーマンスを最適化
+ *   - password_encrypted はAES-256-GCM暗号化済み（平文で保存しない）
+ *
+ * マイグレーション方針:
+ *   - 既存のSQLiteデータベースは再作成する（既存の会話履歴は破棄許可済み）
+ *   - db_connectionsテーブルを新規作成
+ *   - conversationsテーブルにdb_connection_idカラムを追加（FK → db_connections.id）
+ *   - 外部キー制約: conversations.db_connection_id → db_connections.id (ON DELETE CASCADE)
  *
  * 参考:
  *   - https://github.com/wiselibs/better-sqlite3/blob/master/README.md
@@ -30,10 +40,35 @@ import fs from 'fs'
 // ---------------------------------------------------------------------------
 
 /**
+ * db_connections テーブルのレコード型（DBから取得した生データ）
+ *
+ * password_encrypted には AES-256-GCM で暗号化されたパスワードが格納される。
+ * 平文パスワードは保存しないこと。
+ */
+export interface DbConnectionRow {
+  id: string
+  name: string
+  db_type: string
+  host: string
+  port: number
+  username: string
+  password_encrypted: string
+  database_name: string
+  is_last_used: number  // SQLite では BOOLEAN は INTEGER（0/1）として保存
+  created_at: string
+  updated_at: string
+}
+
+/**
  * conversations テーブルのレコード型（DBから取得した生データ）
+ *
+ * db_connection_id は DB接続先との FK（ON DELETE CASCADE）。
+ * db.md の変更に伴い db_connection_id カラムを追加。
+ * 後続PBI #147 でDB接続先管理が実装されるまでは NULL が格納される場合がある。
  */
 export interface ConversationRow {
   id: string
+  db_connection_id: string | null
   title: string
   created_at: string
   updated_at: string
@@ -72,9 +107,14 @@ export interface CreateMessageParams {
 
 /**
  * conversation 作成時の入力パラメータ型
+ *
+ * db_connection_id: DB接続先ID（FK → db_connections.id）。
+ *   後続PBI #147 でDB接続先管理が実装されるまでは省略可能（NULL が格納される）。
+ *   後続PBIで必須フィールドに変更予定。
  */
 export interface CreateConversationParams {
   id: string
+  db_connection_id?: string | null
   title: string
 }
 
@@ -156,36 +196,97 @@ export function initHistoryDb(dbPath?: string): Database.Database {
 /**
  * テーブルマイグレーションを実行する
  *
- * CREATE TABLE IF NOT EXISTS でべき等に実行可能。
- * 起動時に毎回呼ばれるが、テーブルが既存の場合はスキップされる。
+ * マイグレーション方針 (ai_generated/requirements/db.md 参照):
+ *   - 既存のSQLiteデータベースは「再作成」する（既存の会話履歴は破棄許可済み）
+ *   - db_connectionsテーブルを新規追加
+ *   - conversationsテーブルにdb_connection_idカラムを追加（FK → db_connections.id）
+ *   - 外部キー制約: conversations.db_connection_id → db_connections.id (ON DELETE CASCADE)
+ *
+ * 再作成の理由:
+ *   既存の conversations テーブルには db_connection_id カラムがなく、
+ *   SQLite の ALTER TABLE では FK 付きカラムを追加できないため、
+ *   テーブルを DROP して再作成する方式を採用する。
  *
  * テーブル仕様は ai_generated/requirements/db.md のER図に準拠。
  *
  * @param db - 初期化済みの Database インスタンス
  */
 function runMigrations(db: Database.Database): void {
-  // conversations テーブル（会話セッション）
+  // ===========================================================================
+  // 既存テーブルを削除して再作成（db.md マイグレーション方針に従う）
+  // ===========================================================================
+  // 削除順序: FK 制約の関係で子テーブルから先に削除する
+  // messages → conversations → db_connections の順に DROP
+  //
+  // 注意: ON DELETE CASCADE が有効でも、DROP TABLE 時は CASCADE は適用されない。
+  // 子テーブルを先に DROP することで FK 制約違反エラーを回避する。
+
+  db.exec(`DROP TABLE IF EXISTS messages`)
+  db.exec(`DROP TABLE IF EXISTS conversations`)
+  db.exec(`DROP TABLE IF EXISTS db_connections`)
+
+  // ===========================================================================
+  // db_connections テーブル（DB接続先管理）[新規追加]
+  // ===========================================================================
   // - id: UUID（クライアント側で生成）
+  // - name: 接続名（表示用）。UNIQUE 制約で重複を防ぐ
+  // - db_type: 'mysql' または 'postgresql'
+  // - host: ホスト名
+  // - port: ポート番号
+  // - username: DBユーザー名
+  // - password_encrypted: AES-256-GCM で暗号化されたパスワード（平文は保存しない）
+  // - database_name: 接続先DBの名前
+  // - is_last_used: 最後に使用したDB フラグ（0/1）。SQLite では BOOLEAN を INTEGER で表現
+  // - created_at / updated_at: ISO 8601 文字列で保存
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS db_connections (
+      id                 TEXT     NOT NULL PRIMARY KEY,
+      name               TEXT     NOT NULL UNIQUE,
+      db_type            TEXT     NOT NULL CHECK(db_type IN ('mysql', 'postgresql')),
+      host               TEXT     NOT NULL,
+      port               INTEGER  NOT NULL,
+      username           TEXT     NOT NULL,
+      password_encrypted TEXT     NOT NULL,
+      database_name      TEXT     NOT NULL,
+      is_last_used       INTEGER  NOT NULL DEFAULT 0,
+      created_at         DATETIME NOT NULL,
+      updated_at         DATETIME NOT NULL
+    )
+  `)
+
+  // ===========================================================================
+  // conversations テーブル（会話セッション）[db_connection_id を追加]
+  // ===========================================================================
+  // - id: UUID（クライアント側で生成）
+  // - db_connection_id: FK → db_connections.id（ON DELETE CASCADE）
+  //   接続先DBが削除されると、その接続に紐づく会話も自動削除される。
+  //   NULL 許容（後続PBI #147 でDB接続先管理が実装されるまでの暫定措置）。
+  //   後続PBIでDB接続先管理が完成したら NOT NULL 制約を追加すること。
   // - title: 会話タイトル（最初のユーザー質問から自動生成）
   // - created_at / updated_at: ISO 8601 文字列で保存
   db.exec(`
     CREATE TABLE IF NOT EXISTS conversations (
-      id         TEXT     NOT NULL PRIMARY KEY,
-      title      TEXT     NOT NULL,
-      created_at DATETIME NOT NULL,
-      updated_at DATETIME NOT NULL
+      id                TEXT     NOT NULL PRIMARY KEY,
+      db_connection_id  TEXT     REFERENCES db_connections(id) ON DELETE CASCADE,
+      title             TEXT     NOT NULL,
+      created_at        DATETIME NOT NULL,
+      updated_at        DATETIME NOT NULL
     )
   `)
 
-  // messages テーブル（個別メッセージ）
+  // ===========================================================================
+  // messages テーブル（個別メッセージ）[変更なし]
+  // ===========================================================================
   // - id: UUID（クライアント側で生成）
-  // - conversation_id: FK → conversations.id（CASCADE削除）
+  // - conversation_id: FK → conversations.id（ON DELETE CASCADE）
+  //   会話が削除されると、そのメッセージも自動削除される
   // - role: 'user' または 'assistant'
   // - content: メッセージ本文
   // - sql: アシスタントが生成したSQL（ユーザーメッセージは NULL）
   // - chart_type: 推奨グラフ種別（bar/line/pie/table）
   // - query_result: クエリ結果JSON文字列（nullable）
   // - error: エラー内容（エラー発生時のみ）
+  // - analysis: AI分析コメント（クエリ結果の傾向・特徴）
   // - created_at: メッセージ作成日時
   db.exec(`
     CREATE TABLE IF NOT EXISTS messages (
@@ -197,16 +298,14 @@ function runMigrations(db: Database.Database): void {
       chart_type      TEXT,
       query_result    TEXT,
       error           TEXT,
+      analysis        TEXT,
       created_at      DATETIME NOT NULL
     )
   `)
 
-  // マイグレーション: analysis カラムを追加（既存DBへの後方互換）
-  try {
-    db.exec(`ALTER TABLE messages ADD COLUMN analysis TEXT`)
-  } catch {
-    // カラムが既に存在する場合は無視（duplicate column name エラー）
-  }
+  // ===========================================================================
+  // インデックス
+  // ===========================================================================
 
   // インデックス: conversation_id での messages 検索を高速化
   db.exec(`
@@ -218,6 +317,12 @@ function runMigrations(db: Database.Database): void {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_conversations_updated_at
       ON conversations(updated_at DESC)
+  `)
+
+  // インデックス: db_connections の is_last_used での検索を高速化（最後に使用した接続を素早く取得）
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_db_connections_is_last_used
+      ON db_connections(is_last_used)
   `)
 }
 
@@ -280,13 +385,14 @@ export function closeHistoryDb(): void {
  * 会話を新規作成する
  *
  * @param db - Database インスタンス（省略時はシングルトン）
- * @param params - 作成パラメータ（id, title）
+ * @param params - 作成パラメータ（id, db_connection_id, title）
  * @returns 作成された ConversationRow
  *
  * @example
  * ```typescript
  * const conv = createConversation(db, {
  *   id: crypto.randomUUID(),
+ *   db_connection_id: 'some-db-connection-id',
  *   title: '売上データを教えて',
  * })
  * ```
@@ -297,11 +403,13 @@ export function createConversation(
 ): ConversationRow {
   const now = new Date().toISOString()
   const stmt = db.prepare(`
-    INSERT INTO conversations (id, title, created_at, updated_at)
-    VALUES (@id, @title, @created_at, @updated_at)
+    INSERT INTO conversations (id, db_connection_id, title, created_at, updated_at)
+    VALUES (@id, @db_connection_id, @title, @created_at, @updated_at)
   `)
   stmt.run({
     id: params.id,
+    // db_connection_id が省略された場合は NULL を格納する（後続PBIで必須化予定）
+    db_connection_id: params.db_connection_id ?? null,
     title: params.title,
     created_at: now,
     updated_at: now,
@@ -337,7 +445,7 @@ export function updateConversationTimestamp(
  */
 export function listConversations(db: Database.Database): ConversationRow[] {
   const stmt = db.prepare(`
-    SELECT id, title, created_at, updated_at
+    SELECT id, db_connection_id, title, created_at, updated_at
     FROM conversations
     ORDER BY updated_at DESC
   `)
@@ -356,7 +464,7 @@ export function getConversationById(
   id: string
 ): ConversationRow | undefined {
   const stmt = db.prepare(`
-    SELECT id, title, created_at, updated_at
+    SELECT id, db_connection_id, title, created_at, updated_at
     FROM conversations
     WHERE id = ?
   `)
@@ -439,7 +547,7 @@ export function getMessageById(
   id: string
 ): MessageRow | undefined {
   const stmt = db.prepare(`
-    SELECT id, conversation_id, role, content, sql, chart_type, query_result, error, created_at
+    SELECT id, conversation_id, role, content, sql, chart_type, query_result, error, analysis, created_at
     FROM messages
     WHERE id = ?
   `)
@@ -460,10 +568,179 @@ export function listMessagesByConversationId(
   conversationId: string
 ): MessageRow[] {
   const stmt = db.prepare(`
-    SELECT id, conversation_id, role, content, sql, chart_type, query_result, error, created_at
+    SELECT id, conversation_id, role, content, sql, chart_type, query_result, error, analysis, created_at
     FROM messages
     WHERE conversation_id = ?
     ORDER BY created_at ASC
   `)
   return stmt.all(conversationId) as MessageRow[]
+}
+
+// ---------------------------------------------------------------------------
+// Repository: db_connections
+// ---------------------------------------------------------------------------
+
+/**
+ * DB接続先を新規作成する
+ *
+ * password は必ず暗号化済みのものを渡すこと（平文パスワードは保存しない）。
+ * AES-256-GCM 暗号化は呼び出し元（config サービス等）が担当する。
+ *
+ * @param db - Database インスタンス
+ * @param params - 作成パラメータ
+ * @returns 作成された DbConnectionRow
+ *
+ * @example
+ * ```typescript
+ * const conn = createDbConnection(db, {
+ *   id: uuidv4(),
+ *   name: '本番DB',
+ *   db_type: 'postgresql',
+ *   host: 'db.example.com',
+ *   port: 5432,
+ *   username: 'readonly_user',
+ *   password_encrypted: encryptedPassword,
+ *   database_name: 'production',
+ * })
+ * ```
+ */
+export function createDbConnection(
+  db: Database.Database,
+  params: {
+    id: string
+    name: string
+    db_type: string
+    host: string
+    port: number
+    username: string
+    password_encrypted: string
+    database_name: string
+  }
+): DbConnectionRow {
+  const now = new Date().toISOString()
+  const stmt = db.prepare(`
+    INSERT INTO db_connections (
+      id, name, db_type, host, port, username, password_encrypted,
+      database_name, is_last_used, created_at, updated_at
+    ) VALUES (
+      @id, @name, @db_type, @host, @port, @username, @password_encrypted,
+      @database_name, 0, @created_at, @updated_at
+    )
+  `)
+  stmt.run({
+    id: params.id,
+    name: params.name,
+    db_type: params.db_type,
+    host: params.host,
+    port: params.port,
+    username: params.username,
+    password_encrypted: params.password_encrypted,
+    database_name: params.database_name,
+    created_at: now,
+    updated_at: now,
+  })
+  return getDbConnectionById(db, params.id)!
+}
+
+/**
+ * 指定IDのDB接続先を取得する
+ *
+ * @param db - Database インスタンス
+ * @param id - 取得するDB接続先ID
+ * @returns DbConnectionRow（存在しない場合は undefined）
+ */
+export function getDbConnectionById(
+  db: Database.Database,
+  id: string
+): DbConnectionRow | undefined {
+  const stmt = db.prepare(`
+    SELECT id, name, db_type, host, port, username, password_encrypted,
+           database_name, is_last_used, created_at, updated_at
+    FROM db_connections
+    WHERE id = ?
+  `)
+  return stmt.get(id) as DbConnectionRow | undefined
+}
+
+/**
+ * DB接続先一覧を取得する（name 昇順）
+ *
+ * @param db - Database インスタンス
+ * @returns DbConnectionRow の配列（name 昇順）
+ */
+export function listDbConnections(db: Database.Database): DbConnectionRow[] {
+  const stmt = db.prepare(`
+    SELECT id, name, db_type, host, port, username, password_encrypted,
+           database_name, is_last_used, created_at, updated_at
+    FROM db_connections
+    ORDER BY name ASC
+  `)
+  return stmt.all() as DbConnectionRow[]
+}
+
+/**
+ * 指定IDのDB接続先を削除する
+ *
+ * conversations テーブルには ON DELETE CASCADE が設定されているため、
+ * db_connections のレコードを削除すると関連 conversations および messages も自動削除される。
+ *
+ * @param db - Database インスタンス
+ * @param id - 削除するDB接続先ID
+ * @returns 削除された行数（0 の場合は対象が存在しなかった）
+ */
+export function deleteDbConnection(db: Database.Database, id: string): number {
+  const stmt = db.prepare(`DELETE FROM db_connections WHERE id = ?`)
+  const result = stmt.run(id)
+  return result.changes
+}
+
+/**
+ * 最後に使用したDB接続先を取得する
+ *
+ * is_last_used = 1 のレコードを取得する。
+ * 複数ある場合は updated_at が最新のものを返す。
+ *
+ * @param db - Database インスタンス
+ * @returns DbConnectionRow（存在しない場合は undefined）
+ */
+export function getLastUsedDbConnection(
+  db: Database.Database
+): DbConnectionRow | undefined {
+  const stmt = db.prepare(`
+    SELECT id, name, db_type, host, port, username, password_encrypted,
+           database_name, is_last_used, created_at, updated_at
+    FROM db_connections
+    WHERE is_last_used = 1
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `)
+  return stmt.get() as DbConnectionRow | undefined
+}
+
+/**
+ * 指定のDB接続先を「最後に使用した」としてマークする
+ *
+ * 他の接続先の is_last_used をすべて 0 にリセットした後、
+ * 指定IDの接続先を is_last_used = 1 に設定する。
+ * トランザクションで atomically に実行する。
+ *
+ * @param db - Database インスタンス
+ * @param id - マークするDB接続先ID
+ */
+export function markDbConnectionAsLastUsed(
+  db: Database.Database,
+  id: string
+): void {
+  // トランザクションで atomically に実行（排他的な is_last_used 管理）
+  const tx = db.transaction(() => {
+    // すべての接続先の is_last_used を 0 にリセット
+    db.prepare(`UPDATE db_connections SET is_last_used = 0`).run()
+    // 指定IDの接続先を is_last_used = 1 に設定し updated_at を更新
+    db.prepare(`
+      UPDATE db_connections
+      SET is_last_used = 1, updated_at = @updated_at
+      WHERE id = @id
+    `).run({ id, updated_at: new Date().toISOString() })
+  })
+  tx()
 }

--- a/output_system/test/unit/historyDb.test.ts
+++ b/output_system/test/unit/historyDb.test.ts
@@ -5,12 +5,17 @@
  * すべてのテストはインメモリDB（':memory:'）を使用し、ファイルを作成しない。
  *
  * テスト対象:
- *   - initHistoryDb()      : テーブルが作成されること
- *   - createConversation() : 会話レコードが作成されること
- *   - listConversations()  : updated_at 降順で一覧取得できること
- *   - getConversationById(): 指定IDの会話を取得できること
- *   - deleteConversation() : 会話とメッセージが CASCADE 削除されること
- *   - createMessage()      : メッセージレコードが作成されること
+ *   - initHistoryDb()         : テーブルが作成されること（db_connections/conversations/messages）
+ *   - createDbConnection()    : DB接続先レコードが作成されること
+ *   - listDbConnections()     : DB接続先一覧を name 昇順で取得できること
+ *   - getDbConnectionById()   : 指定IDのDB接続先を取得できること
+ *   - deleteDbConnection()    : DB接続先とその会話・メッセージが CASCADE 削除されること
+ *   - markDbConnectionAsLastUsed(): is_last_used フラグが排他的に更新されること
+ *   - createConversation()    : 会話レコードが作成されること（db_connection_id が必須）
+ *   - listConversations()     : updated_at 降順で一覧取得できること
+ *   - getConversationById()   : 指定IDの会話を取得できること
+ *   - deleteConversation()    : 会話とメッセージが CASCADE 削除されること
+ *   - createMessage()         : メッセージレコードが作成されること
  *   - listMessagesByConversationId(): 会話に紐づくメッセージ一覧を取得できること
  */
 
@@ -22,6 +27,12 @@ import {
   getHistoryDb,
   setHistoryDbInstance,
   closeHistoryDb,
+  createDbConnection,
+  listDbConnections,
+  getDbConnectionById,
+  deleteDbConnection,
+  getLastUsedDbConnection,
+  markDbConnectionAsLastUsed,
   createConversation,
   listConversations,
   getConversationById,
@@ -44,6 +55,28 @@ function createTestDb(): Database.Database {
   return initHistoryDb(':memory:')
 }
 
+/**
+ * テスト用のDB接続先を作成するヘルパー
+ * conversations テーブルは db_connection_id が必須のため、
+ * 会話テストでも使用する。
+ *
+ * @param db - テスト用インメモリDB
+ * @param id - DB接続先ID（省略時は 'test-conn-id'）
+ * @returns 作成されたDB接続先レコード
+ */
+function createTestDbConnection(db: Database.Database, id = 'test-conn-id') {
+  return createDbConnection(db, {
+    id,
+    name: `テスト接続-${id}`,
+    db_type: 'postgresql',
+    host: 'localhost',
+    port: 5432,
+    username: 'test_user',
+    password_encrypted: 'encrypted_password_for_test',
+    database_name: 'test_db',
+  })
+}
+
 // ---------------------------------------------------------------------------
 // テストスイート
 // ---------------------------------------------------------------------------
@@ -51,10 +84,10 @@ function createTestDb(): Database.Database {
 describe('historyDb: initHistoryDb', () => {
   /**
    * 【テスト対象】initHistoryDb()
-   * 【テスト内容】インメモリDBで初期化した場合にテーブルが作成されること
-   * 【期待結果】conversations テーブルと messages テーブルが存在すること
+   * 【テスト内容】インメモリDBで初期化した場合にすべてのテーブルが作成されること
+   * 【期待結果】db_connections / conversations / messages テーブルが存在すること
    */
-  it('should create conversations and messages tables on init', () => {
+  it('should create db_connections, conversations and messages tables on init', () => {
     const db = createTestDb()
 
     // sqlite_master を使ってテーブル存在を確認
@@ -64,8 +97,27 @@ describe('historyDb: initHistoryDb', () => {
       ).all() as { name: string }[]
     ).map((r) => r.name)
 
+    expect(tables).toContain('db_connections')
     expect(tables).toContain('conversations')
     expect(tables).toContain('messages')
+
+    db.close()
+  })
+
+  /**
+   * 【テスト対象】initHistoryDb()
+   * 【テスト内容】conversations テーブルに db_connection_id カラムが存在すること
+   * 【期待結果】PRAGMA table_info で db_connection_id カラムが確認できること
+   */
+  it('should have db_connection_id column in conversations table', () => {
+    const db = createTestDb()
+
+    // PRAGMA table_info でカラム一覧を取得
+    const columns = (
+      db.prepare(`PRAGMA table_info(conversations)`).all() as { name: string }[]
+    ).map((c) => c.name)
+
+    expect(columns).toContain('db_connection_id')
 
     db.close()
   })
@@ -87,7 +139,8 @@ describe('historyDb: initHistoryDb', () => {
   /**
    * 【テスト対象】initHistoryDb()
    * 【テスト内容】インデックスが作成されること
-   * 【期待結果】idx_messages_conversation_id と idx_conversations_updated_at が存在すること
+   * 【期待結果】idx_messages_conversation_id / idx_conversations_updated_at /
+   *             idx_db_connections_is_last_used が存在すること
    */
   it('should create indexes for performance', () => {
     const db = createTestDb()
@@ -100,6 +153,7 @@ describe('historyDb: initHistoryDb', () => {
 
     expect(indexes).toContain('idx_messages_conversation_id')
     expect(indexes).toContain('idx_conversations_updated_at')
+    expect(indexes).toContain('idx_db_connections_is_last_used')
 
     db.close()
   })
@@ -110,6 +164,8 @@ describe('historyDb: conversations Repository', () => {
 
   beforeEach(() => {
     db = createTestDb()
+    // conversations には db_connection_id（FK）が必須のため、事前にDB接続先を作成する
+    createTestDbConnection(db)
   })
 
   afterEach(() => {
@@ -119,15 +175,17 @@ describe('historyDb: conversations Repository', () => {
   /**
    * 【テスト対象】createConversation()
    * 【テスト内容】正常な入力で会話レコードが作成されること
-   * 【期待結果】id, title, created_at, updated_at が設定された ConversationRow が返ること
+   * 【期待結果】id, db_connection_id, title, created_at, updated_at が設定された ConversationRow が返ること
    */
-  it('should create a conversation with correct fields', () => {
+  it('should create a conversation with correct fields including db_connection_id', () => {
     const conv = createConversation(db, {
       id: 'test-conv-id-1',
+      db_connection_id: 'test-conn-id',
       title: '売上データを教えて',
     })
 
     expect(conv.id).toBe('test-conv-id-1')
+    expect(conv.db_connection_id).toBe('test-conn-id')
     expect(conv.title).toBe('売上データを教えて')
     expect(conv.created_at).toBeTruthy()
     expect(conv.updated_at).toBeTruthy()
@@ -142,9 +200,9 @@ describe('historyDb: conversations Repository', () => {
    */
   it('should return conversations ordered by updated_at DESC', () => {
     // 3件の会話を作成
-    createConversation(db, { id: 'conv-1', title: '最初の質問' })
-    createConversation(db, { id: 'conv-2', title: '2番目の質問' })
-    createConversation(db, { id: 'conv-3', title: '3番目の質問' })
+    createConversation(db, { id: 'conv-1', db_connection_id: 'test-conn-id', title: '最初の質問' })
+    createConversation(db, { id: 'conv-2', db_connection_id: 'test-conn-id', title: '2番目の質問' })
+    createConversation(db, { id: 'conv-3', db_connection_id: 'test-conn-id', title: '3番目の質問' })
 
     // conv-1 を更新（updated_at を新しくする）
     updateConversationTimestamp(db, 'conv-1')
@@ -159,15 +217,16 @@ describe('historyDb: conversations Repository', () => {
   /**
    * 【テスト対象】getConversationById()
    * 【テスト内容】存在するIDを指定したとき、対応する会話レコードが返ること
-   * 【期待結果】指定IDの ConversationRow が返ること
+   * 【期待結果】指定IDの ConversationRow が返ること（db_connection_id を含む）
    */
-  it('should return conversation by id', () => {
-    createConversation(db, { id: 'find-conv-id', title: 'テスト会話' })
+  it('should return conversation by id with db_connection_id', () => {
+    createConversation(db, { id: 'find-conv-id', db_connection_id: 'test-conn-id', title: 'テスト会話' })
 
     const found = getConversationById(db, 'find-conv-id')
 
     expect(found).toBeDefined()
     expect(found!.id).toBe('find-conv-id')
+    expect(found!.db_connection_id).toBe('test-conn-id')
     expect(found!.title).toBe('テスト会話')
   })
 
@@ -187,7 +246,7 @@ describe('historyDb: conversations Repository', () => {
    * 【期待結果】changes が 1、削除後は getConversationById が undefined を返すこと
    */
   it('should delete conversation and return changes count of 1', () => {
-    createConversation(db, { id: 'del-conv-id', title: '削除テスト' })
+    createConversation(db, { id: 'del-conv-id', db_connection_id: 'test-conn-id', title: '削除テスト' })
 
     const changes = deleteConversation(db, 'del-conv-id')
 
@@ -211,7 +270,7 @@ describe('historyDb: conversations Repository', () => {
    * 【期待結果】削除後に listMessagesByConversationId が空配列を返すこと
    */
   it('should cascade delete messages when conversation is deleted', () => {
-    createConversation(db, { id: 'cascade-conv', title: 'カスケード削除テスト' })
+    createConversation(db, { id: 'cascade-conv', db_connection_id: 'test-conn-id', title: 'カスケード削除テスト' })
     createMessage(db, {
       id: 'msg-1',
       conversationId: 'cascade-conv',
@@ -239,8 +298,9 @@ describe('historyDb: messages Repository', () => {
 
   beforeEach(() => {
     db = createTestDb()
-    // メッセージテストには会話が必要
-    createConversation(db, { id: 'test-conv', title: 'テスト会話' })
+    // メッセージテストには会話が必要。会話には db_connection_id（FK）が必須
+    createTestDbConnection(db)
+    createConversation(db, { id: 'test-conv', db_connection_id: 'test-conn-id', title: 'テスト会話' })
   })
 
   afterEach(() => {
@@ -387,8 +447,8 @@ describe('historyDb: messages Repository', () => {
    * 【期待結果】指定した conversation_id のメッセージのみ返ること
    */
   it('should only return messages for the specified conversation', () => {
-    // 別の会話を作成
-    createConversation(db, { id: 'other-conv', title: '別の会話' })
+    // 別の会話を作成（同じDB接続先を使用）
+    createConversation(db, { id: 'other-conv', db_connection_id: 'test-conn-id', title: '別の会話' })
 
     createMessage(db, {
       id: 'my-msg',
@@ -417,6 +477,267 @@ describe('historyDb: messages Repository', () => {
   it('should return empty array for non-existent conversation', () => {
     const messages = listMessagesByConversationId(db, 'non-existent-conv')
     expect(messages).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// db_connections Repository
+// ---------------------------------------------------------------------------
+
+describe('historyDb: db_connections Repository', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  /**
+   * 【テスト対象】createDbConnection()
+   * 【テスト内容】正常な入力でDB接続先レコードが作成されること
+   * 【期待結果】id, name, db_type, host, port, username, database_name, is_last_used=0 が設定されること
+   */
+  it('should create a db connection with correct fields', () => {
+    const conn = createDbConnection(db, {
+      id: 'conn-id-1',
+      name: '本番PostgreSQL',
+      db_type: 'postgresql',
+      host: 'db.example.com',
+      port: 5432,
+      username: 'readonly_user',
+      password_encrypted: 'AES256GCM_ENCRYPTED_VALUE',
+      database_name: 'production',
+    })
+
+    expect(conn.id).toBe('conn-id-1')
+    expect(conn.name).toBe('本番PostgreSQL')
+    expect(conn.db_type).toBe('postgresql')
+    expect(conn.host).toBe('db.example.com')
+    expect(conn.port).toBe(5432)
+    expect(conn.username).toBe('readonly_user')
+    expect(conn.password_encrypted).toBe('AES256GCM_ENCRYPTED_VALUE')
+    expect(conn.database_name).toBe('production')
+    // is_last_used は作成直後は 0（false）であること
+    expect(conn.is_last_used).toBe(0)
+    expect(conn.created_at).toBeTruthy()
+    expect(conn.updated_at).toBeTruthy()
+    expect(conn.created_at).toBe(conn.updated_at)
+  })
+
+  /**
+   * 【テスト対象】createDbConnection()
+   * 【テスト内容】mysql タイプでDB接続先を作成できること
+   * 【期待結果】db_type が 'mysql' のレコードが作成されること
+   */
+  it('should create a mysql type db connection', () => {
+    const conn = createDbConnection(db, {
+      id: 'mysql-conn-1',
+      name: '開発MySQL',
+      db_type: 'mysql',
+      host: 'localhost',
+      port: 3306,
+      username: 'dev_user',
+      password_encrypted: 'ENCRYPTED_DEV_PASSWORD',
+      database_name: 'dev_db',
+    })
+
+    expect(conn.db_type).toBe('mysql')
+    expect(conn.port).toBe(3306)
+  })
+
+  /**
+   * 【テスト対象】listDbConnections()
+   * 【テスト内容】複数のDB接続先を作成したとき、name 昇順で一覧取得できること
+   * 【期待結果】name アルファベット順でソートされたリストが返ること
+   */
+  it('should return db connections ordered by name ASC', () => {
+    createDbConnection(db, {
+      id: 'conn-z', name: 'Z接続', db_type: 'postgresql', host: 'h1',
+      port: 5432, username: 'u1', password_encrypted: 'enc1', database_name: 'db1',
+    })
+    createDbConnection(db, {
+      id: 'conn-a', name: 'A接続', db_type: 'mysql', host: 'h2',
+      port: 3306, username: 'u2', password_encrypted: 'enc2', database_name: 'db2',
+    })
+    createDbConnection(db, {
+      id: 'conn-m', name: 'M接続', db_type: 'postgresql', host: 'h3',
+      port: 5432, username: 'u3', password_encrypted: 'enc3', database_name: 'db3',
+    })
+
+    const connections = listDbConnections(db)
+
+    expect(connections).toHaveLength(3)
+    // name 昇順: A → M → Z
+    expect(connections[0].name).toBe('A接続')
+    expect(connections[1].name).toBe('M接続')
+    expect(connections[2].name).toBe('Z接続')
+  })
+
+  /**
+   * 【テスト対象】getDbConnectionById()
+   * 【テスト内容】存在するIDを指定したとき、対応するDB接続先が返ること
+   * 【期待結果】指定IDの DbConnectionRow が返ること
+   */
+  it('should return db connection by id', () => {
+    createDbConnection(db, {
+      id: 'find-conn-id', name: '検索テスト', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+
+    const found = getDbConnectionById(db, 'find-conn-id')
+
+    expect(found).toBeDefined()
+    expect(found!.id).toBe('find-conn-id')
+    expect(found!.name).toBe('検索テスト')
+  })
+
+  /**
+   * 【テスト対象】getDbConnectionById()
+   * 【テスト内容】存在しないIDを指定したとき、undefined が返ること
+   * 【期待結果】undefined が返ること
+   */
+  it('should return undefined for non-existent db connection id', () => {
+    const result = getDbConnectionById(db, 'non-existent-id')
+    expect(result).toBeUndefined()
+  })
+
+  /**
+   * 【テスト対象】deleteDbConnection()
+   * 【テスト内容】存在するDB接続先を削除したとき、1が返り存在しなくなること
+   * 【期待結果】changes が 1、削除後は getDbConnectionById が undefined を返すこと
+   */
+  it('should delete db connection and return changes count of 1', () => {
+    createDbConnection(db, {
+      id: 'del-conn-id', name: '削除テスト', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+
+    const changes = deleteDbConnection(db, 'del-conn-id')
+
+    expect(changes).toBe(1)
+    expect(getDbConnectionById(db, 'del-conn-id')).toBeUndefined()
+  })
+
+  /**
+   * 【テスト対象】deleteDbConnection()
+   * 【テスト内容】DB接続先を削除したとき、紐づく会話とメッセージも CASCADE 削除されること
+   * 【期待結果】削除後に getConversationById が undefined を返すこと
+   */
+  it('should cascade delete conversations when db connection is deleted', () => {
+    createDbConnection(db, {
+      id: 'cascade-conn', name: 'カスケード接続', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+    createConversation(db, {
+      id: 'cascade-conv-from-conn',
+      db_connection_id: 'cascade-conn',
+      title: 'カスケード削除テスト会話',
+    })
+
+    // DB接続先を削除
+    deleteDbConnection(db, 'cascade-conn')
+
+    // 紐づく会話も削除されていること
+    expect(getConversationById(db, 'cascade-conv-from-conn')).toBeUndefined()
+  })
+
+  /**
+   * 【テスト対象】markDbConnectionAsLastUsed()
+   * 【テスト内容】指定のDB接続先が is_last_used = 1 にマークされること
+   * 【期待結果】マークした接続先の is_last_used が 1 で、他は 0 であること
+   */
+  it('should mark only specified db connection as last used', () => {
+    // 3件のDB接続先を作成
+    createDbConnection(db, {
+      id: 'conn-1', name: '接続1', db_type: 'postgresql', host: 'h1',
+      port: 5432, username: 'u1', password_encrypted: 'enc1', database_name: 'db1',
+    })
+    createDbConnection(db, {
+      id: 'conn-2', name: '接続2', db_type: 'mysql', host: 'h2',
+      port: 3306, username: 'u2', password_encrypted: 'enc2', database_name: 'db2',
+    })
+    createDbConnection(db, {
+      id: 'conn-3', name: '接続3', db_type: 'postgresql', host: 'h3',
+      port: 5432, username: 'u3', password_encrypted: 'enc3', database_name: 'db3',
+    })
+
+    // conn-2 をマーク
+    markDbConnectionAsLastUsed(db, 'conn-2')
+
+    const conn1 = getDbConnectionById(db, 'conn-1')
+    const conn2 = getDbConnectionById(db, 'conn-2')
+    const conn3 = getDbConnectionById(db, 'conn-3')
+
+    expect(conn1!.is_last_used).toBe(0)
+    expect(conn2!.is_last_used).toBe(1)
+    expect(conn3!.is_last_used).toBe(0)
+  })
+
+  /**
+   * 【テスト対象】markDbConnectionAsLastUsed()
+   * 【テスト内容】マーク先を変更したとき、前のマークがリセットされること
+   * 【期待結果】最新のマーク先のみ is_last_used = 1 であること
+   */
+  it('should reset previous last used flag when marking another connection', () => {
+    createDbConnection(db, {
+      id: 'conn-A', name: 'A接続', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+    createDbConnection(db, {
+      id: 'conn-B', name: 'B接続', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+
+    // まず conn-A をマーク
+    markDbConnectionAsLastUsed(db, 'conn-A')
+    expect(getDbConnectionById(db, 'conn-A')!.is_last_used).toBe(1)
+
+    // conn-B に変更
+    markDbConnectionAsLastUsed(db, 'conn-B')
+
+    // conn-A のフラグがリセットされ、conn-B のみ 1 になること
+    expect(getDbConnectionById(db, 'conn-A')!.is_last_used).toBe(0)
+    expect(getDbConnectionById(db, 'conn-B')!.is_last_used).toBe(1)
+  })
+
+  /**
+   * 【テスト対象】getLastUsedDbConnection()
+   * 【テスト内容】is_last_used = 1 の接続先が返ること
+   * 【期待結果】markDbConnectionAsLastUsed でマークした接続先が返ること
+   */
+  it('should return last used db connection', () => {
+    createDbConnection(db, {
+      id: 'conn-last', name: '最後に使用', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+    createDbConnection(db, {
+      id: 'conn-other', name: '別の接続', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db2',
+    })
+
+    markDbConnectionAsLastUsed(db, 'conn-last')
+
+    const lastUsed = getLastUsedDbConnection(db)
+    expect(lastUsed).toBeDefined()
+    expect(lastUsed!.id).toBe('conn-last')
+  })
+
+  /**
+   * 【テスト対象】getLastUsedDbConnection()
+   * 【テスト内容】is_last_used = 1 の接続先がない場合、undefined が返ること
+   * 【期待結果】undefined が返ること
+   */
+  it('should return undefined when no db connection is marked as last used', () => {
+    createDbConnection(db, {
+      id: 'conn-no-last', name: '未使用', db_type: 'postgresql', host: 'h',
+      port: 5432, username: 'u', password_encrypted: 'enc', database_name: 'db',
+    })
+
+    const lastUsed = getLastUsedDbConnection(db)
+    expect(lastUsed).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

バックエンド起動時にSQLite内部DBが自動初期化され、db_connections / conversations / messages の3テーブルが作成されるようになった。
DB接続先管理機能の追加に向けてスキーマを拡張し、外部キー制約（ON DELETE CASCADE）も正しく設定されている。

### 実装内容

**対象PBI**: #146 SQLiteデータベースが起動時に自動初期化される

- #157 Task 1.2.1: SQLiteデータベース初期化スクリプトを実装する ✅

### 変更ファイル

**バックエンド（スキーマ変更）**
- `output_system/backend/src/services/historyDb.ts`
  - `db_connections` テーブルを新規追加（id, name, db_type, host, port, username, password_encrypted, database_name, is_last_used, created_at, updated_at）
  - `conversations` テーブルに `db_connection_id` カラムを追加（FK → db_connections.id, ON DELETE CASCADE）
  - マイグレーション: 既存テーブルを DROP して再作成（db.md 方針に従い既存履歴は破棄許可済み）
  - `DbConnectionRow` 型を追加
  - `ConversationRow.db_connection_id` を追加（後続PBI #147 まで nullable）
  - Repository 関数を追加: `createDbConnection`, `listDbConnections`, `getDbConnectionById`, `deleteDbConnection`, `getLastUsedDbConnection`, `markDbConnectionAsLastUsed`

**テスト**
- `output_system/test/unit/historyDb.test.ts`
  - `db_connections` テーブル存在確認テストを追加
  - `conversations.db_connection_id` カラム存在確認テストを追加
  - `db_connections Repository` テストスイートを新規追加（10件）
  - インデックス確認テストに `idx_db_connections_is_last_used` を追加

## Test Plan

- [x] バックエンド起動時にSQLiteファイルが作成される
- [x] db_connections / conversations / messages の3テーブルが存在する（ユニットテストで検証）
- [x] conversations.db_connection_id → db_connections.id の FK 制約（ON DELETE CASCADE）が設定されている
- [x] messages.conversation_id → conversations.id の FK 制約（ON DELETE CASCADE）が設定されている
- [x] better-sqlite3 が WAL モードで動作している（`PRAGMA journal_mode = WAL`）
- [x] 全180件のユニットテストが通過

## Related Issues

- Closes #146

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)