### PR TITLE
feat(pbi-149): DB接続先選択による自然言語SQL生成・実行

### DIFF
--- a/output_system/backend/src/index.ts
+++ b/output_system/backend/src/index.ts
@@ -7,7 +7,7 @@
 import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'
-import { closeDb } from './services/database'
+import { destroyAllConnections } from './services/database'
 import { initHistoryDb, closeHistoryDb } from './services/historyDb'
 import schemaRouter from './routes/schema'
 import chatRouter from './routes/chat'
@@ -171,7 +171,8 @@ async function gracefulShutdown(signal: string): Promise<void> {
   console.log(`${signal} received. Shutting down gracefully...`)
   server.close(async () => {
     try {
-      await closeDb()
+      // PBI #149: 動的DB接続のプールを全て破棄
+      await destroyAllConnections()
       console.log('DB connection closed.')
     } catch (err) {
       console.error('Error closing DB connection:', err)

--- a/output_system/backend/src/routes/chat.ts
+++ b/output_system/backend/src/routes/chat.ts
@@ -2,17 +2,23 @@
  * /api/chat ルート（SSE ストリーミング）
  *
  * 自然言語の質問を受け取り、以下の処理を順次行いSSEで結果をストリーミングする:
- *   1. DBスキーマ取得（services/schema.ts）
+ *   1. dbConnectionId から DBスキーマ取得（services/schema.ts / キャッシュ優先）
  *   2. Claude API でSQL・グラフ種別を生成（services/llm.ts）
  *   3. SQLバリデーション（services/sqlValidator.ts 経由 / database.executeQuery 内）
- *   4. SQL実行（services/database.ts）
+ *   4. SQL実行（services/database.ts / 指定DB接続先）
  *   5. 結果を SSE イベントとして送信
  *
+ * PBI #149 改修:
+ *   - リクエストボディから dbConnectionId を受け取り、スキーマ取得・クエリ実行に渡す
+ *   - dbConnectionId が未指定の場合は 400 エラーを返す
+ *
  * SSEイベント仕様（api.md参照）:
+ *   event: conversation - 会話ID通知（新規会話作成時）
  *   event: message  - LLMが生成したテキストチャンク（逐次送信）
  *   event: sql      - 抽出したSQL文
  *   event: chart_type - 推奨グラフ種別（bar/line/pie/table）
  *   event: result   - クエリ実行結果（QueryResult形式）
+ *   event: analysis - AI分析コメントチャンク（逐次送信）
  *   event: error    - エラーメッセージ
  *   event: done     - ストリーム終了（必ず最後に送信）
  *
@@ -25,7 +31,7 @@
 import { Router, Request, Response } from 'express'
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
 import { v4 as uuidv4, validate as uuidValidate } from 'uuid'
-import { fetchSchema } from '../services/schema'
+import { fetchSchema, ConnectionNotFoundError as SchemaConnectionNotFoundError } from '../services/schema'
 import { LlmService, LlmConfigError, LlmApiError, LlmTimeoutError, LlmParseError, ConversationMessage } from '../services/llm'
 import { executeQuery, SqlValidationError } from '../services/database'
 import {
@@ -87,7 +93,7 @@ const chatRateLimiter = rateLimit({
  *   \n
  *
  * @param res - Express レスポンスオブジェクト
- * @param event - SSE イベント名（message/sql/chart_type/result/error/done）
+ * @param event - SSE イベント名（conversation/message/sql/chart_type/result/analysis/error/done）
  * @param data - 送信するデータ（JSON シリアライズ可能な値）
  */
 function sendSseEvent(res: Response, event: string, data: unknown): void {
@@ -105,9 +111,11 @@ function sendSseEvent(res: Response, event: string, data: unknown): void {
  * POST /api/chat
  *
  * リクエストボディ:
- *   { message: string, conversationId?: string }
- *
- *   message: 必須。2000文字以内。
+ *   {
+ *     message: string,           // 必須。2000文字以内。
+ *     dbConnectionId: string,    // 必須（PBI #149 追加）。DB接続先ID（UUID）。
+ *     conversationId?: string    // 任意。継続会話の場合に指定。
+ *   }
  *
  * レスポンス:
  *   Content-Type: text/event-stream（SSEストリーム）
@@ -116,7 +124,9 @@ function sendSseEvent(res: Response, event: string, data: unknown): void {
  * エラーハンドリング:
  *   - message 未設定: 400エラー（SSE開始前に返す）
  *   - message が2000文字超: 400エラー（SSE開始前に返す）
- *   - DB接続エラー: event: error 送信後 event: done
+ *   - dbConnectionId 未設定: 400エラー（SSE開始前に返す）
+ *   - DB接続先が見つからない: event: error 送信後 event: done
+ *   - DBスキーマ取得エラー: event: error 送信後 event: done
  *   - LLM設定エラー（APIキー未設定）: event: error 送信後 event: done
  *   - LLM APIエラー: event: error 送信後 event: done
  *   - SQLバリデーション失敗: event: error 送信後 event: done
@@ -126,8 +136,16 @@ function sendSseEvent(res: Response, event: string, data: unknown): void {
  *   - 内部エラー詳細（DBホスト名等）はサーバーログにのみ記録し、レスポンスには含めない
  */
 router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<void> => {
-  // リクエストボディから message と conversationId を取得
-  const { message, conversationId: reqConversationId } = req.body as { message?: string; conversationId?: string }
+  // リクエストボディから message、dbConnectionId、conversationId を取得
+  const {
+    message,
+    dbConnectionId,
+    conversationId: reqConversationId,
+  } = req.body as {
+    message?: string
+    dbConnectionId?: string
+    conversationId?: string
+  }
 
   // message のバリデーション（SSEヘッダー送信前に400で返す）
   if (!message || typeof message !== 'string' || message.trim() === '') {
@@ -137,6 +155,18 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
 
   if (message.length > MESSAGE_MAX_LENGTH) {
     res.status(400).json({ error: `message は ${MESSAGE_MAX_LENGTH} 文字以内で入力してください。` })
+    return
+  }
+
+  // dbConnectionId のバリデーション（PBI #149 追加: 必須フィールド）
+  if (!dbConnectionId || typeof dbConnectionId !== 'string' || dbConnectionId.trim() === '') {
+    res.status(400).json({ error: 'dbConnectionId フィールドは必須です。DB接続先を選択してください。' })
+    return
+  }
+
+  // UUID v4 形式チェック（不正なIDを早期に弾く）
+  if (!uuidValidate(dbConnectionId)) {
+    res.status(400).json({ error: 'dbConnectionId の形式が不正です。' })
     return
   }
 
@@ -235,15 +265,22 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
 
   try {
     // -----------------------------------------------------------------------
-    // Step 1: DBスキーマ取得
+    // Step 1: DBスキーマ取得（dbConnectionId 指定のDB接続先から、キャッシュ優先）
     // -----------------------------------------------------------------------
     let schema
     try {
-      schema = await fetchSchema()
+      // PBI #149: dbConnectionId を渡して指定DB接続先のスキーマを取得
+      schema = await fetchSchema(dbConnectionId)
     } catch (err) {
       // 内部エラー詳細はサーバーログに記録し、ユーザーには一般的なメッセージを返す
       console.error('[chat] fetchSchema error:', err)
-      sendSseEvent(res, 'error', { message: 'DBスキーマの取得に失敗しました。' })
+
+      // 接続先が見つからない場合は専用メッセージ
+      if (err instanceof SchemaConnectionNotFoundError) {
+        sendSseEvent(res, 'error', { message: '指定されたDB接続先が見つかりません。接続先設定を確認してください。' })
+      } else {
+        sendSseEvent(res, 'error', { message: 'DBスキーマの取得に失敗しました。接続先の設定とDB状態を確認してください。' })
+      }
       return
     }
 
@@ -344,7 +381,7 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
     }
 
     // -----------------------------------------------------------------------
-    // Step 4: SQL バリデーション + クエリ実行
+    // Step 4: SQL バリデーション + クエリ実行（指定DB接続先で実行）
     // -----------------------------------------------------------------------
     if (!extractedSql) {
       // SQL が生成されなかった場合（通常は LlmParseError が先にスローされるはず）
@@ -357,7 +394,8 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
     try {
       // executeQuery() 内で sqlValidator が呼ばれる（二重防御）
       // SELECT 以外のSQL は SqlValidationError をスロー
-      const queryResult = await executeQuery(extractedSql)
+      // PBI #149: dbConnectionId を渡して指定DB接続先でクエリを実行
+      const queryResult = await executeQuery(dbConnectionId, extractedSql)
 
       // クエリ結果を送信
       sendSseEvent(res, 'result', {
@@ -435,6 +473,7 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
  * @param chartType      - グラフ種別（nullable）
  * @param queryResult    - クエリ実行結果（nullable）
  * @param error          - エラーメッセージ（nullable）
+ * @param analysis       - AI分析コメント（nullable）
  */
 function _saveAssistantMessage(
   conversationId: string,

--- a/output_system/backend/src/routes/connections.ts
+++ b/output_system/backend/src/routes/connections.ts
@@ -32,6 +32,8 @@ import {
   ConnectionNotFoundError,
   DbConnectionInput,
 } from '../services/connectionManager'
+import { invalidateSchemaCache } from '../services/schema'
+import { destroyConnection } from '../services/database'
 
 const router = Router()
 
@@ -234,7 +236,7 @@ router.post('/test', async (req: Request, res: Response) => {
  * @returns 404 Not Found - 指定IDが存在しない
  * @returns 409 Conflict - 接続名の重複
  */
-router.put('/:id', (req: Request<{ id: string }>, res: Response) => {
+router.put('/:id', async (req: Request<{ id: string }>, res: Response) => {
   const { id } = req.params
 
   // リクエストボディをバリデーション（パスワード省略可）
@@ -245,6 +247,12 @@ router.put('/:id', (req: Request<{ id: string }>, res: Response) => {
 
   try {
     const updated = update(id, validation.input!)
+
+    // PBI #149: 接続先更新時にスキーマキャッシュと接続プールを無効化する
+    // 接続先情報が変わった場合、古いキャッシュを使い続けないよう即座に無効化する
+    invalidateSchemaCache(id)
+    await destroyConnection(id)
+
     return res.status(200).json(updated)
   } catch (err) {
     if (err instanceof ConnectionNotFoundError) {
@@ -269,11 +277,17 @@ router.put('/:id', (req: Request<{ id: string }>, res: Response) => {
  * @returns 204 No Content - 削除成功（ボディなし）
  * @returns 404 Not Found - 指定IDが存在しない
  */
-router.delete('/:id', (req: Request<{ id: string }>, res: Response) => {
+router.delete('/:id', async (req: Request<{ id: string }>, res: Response) => {
   const { id } = req.params
 
   try {
     remove(id)
+
+    // PBI #149: 接続先削除時にスキーマキャッシュと接続プールを無効化する
+    // 削除された接続先のリソースを速やかに解放してメモリリークを防ぐ
+    invalidateSchemaCache(id)
+    await destroyConnection(id)
+
     // 204 No Content: 削除成功はボディを返さない（RESTの慣例）
     return res.status(204).send()
   } catch (err) {

--- a/output_system/backend/src/routes/schema.ts
+++ b/output_system/backend/src/routes/schema.ts
@@ -1,58 +1,100 @@
 /**
  * /api/schema ルート
  *
- * 接続先DBのスキーマ情報を返すエンドポイント。
+ * 指定DB接続先のスキーマ情報を返すエンドポイント。
  * services/schema.ts の fetchSchema() を呼び出し、JSON形式で返却する。
  *
+ * PBI #149 改修:
+ *   - GET /api/schema?dbConnectionId=xxx: dbConnectionId クエリパラメータに対応
+ *   - dbConnectionId が未指定の場合は 400 エラーを返す
+ *   - 接続先が見つからない場合は 404 エラーを返す
+ *
  * エンドポイント仕様 (api.md 参照):
- *   GET /api/schema
- *   200: { database: string, tables: [{ name: string, columns: [...] }] }
- *   500: { error: string, details?: string }
+ *   GET /api/schema?dbConnectionId=<uuid>
+ *   200: { database: string, tables: [{ name: string, comment: string|null, columns: [...] }] }
+ *   400: { error: string }（dbConnectionId 未指定 / 形式不正）
+ *   404: { error: string }（接続先が見つからない）
+ *   500: { error: string, details?: string }（DB接続エラー等）
  */
 
 import { Router, Request, Response } from 'express'
-import { fetchSchema } from '../services/schema'
+import { validate as uuidValidate } from 'uuid'
+import { fetchSchema, ConnectionNotFoundError } from '../services/schema'
 
 const router = Router()
 
 /**
  * GET /api/schema
- * 接続先DBのテーブル・カラム情報を取得する
+ * 指定DB接続先のテーブル・カラム情報を取得する
  *
- * DB_TYPE に応じて PostgreSQL / MySQL の INFORMATION_SCHEMA を参照し、
- * テーブル名・カラム名・型・NULL許容の一覧を返す。
+ * クエリパラメータ:
+ *   dbConnectionId (必須): DB接続先ID（UUID）
+ *
+ * スキーマキャッシュが存在する場合はキャッシュから返す（高速レスポンス）。
+ * キャッシュがない場合はDB接続してスキーマを取得し、キャッシュに保存する。
  *
  * @returns 200 - スキーマ情報JSON
+ * @returns 400 - dbConnectionId 未指定 / UUID形式不正
+ * @returns 404 - 指定IDの接続先が見つからない
  * @returns 500 - DB接続エラーまたはクエリエラー
  *
  * @example
  * ```
- * GET /api/schema
+ * GET /api/schema?dbConnectionId=550e8400-e29b-41d4-a716-446655440000
  * Response: {
  *   "database": "mydb",
  *   "tables": [
  *     {
  *       "name": "users",
+ *       "comment": "ユーザーマスタ",
  *       "columns": [
- *         { "name": "id",    "type": "integer", "nullable": false },
- *         { "name": "email", "type": "character varying", "nullable": false }
+ *         { "name": "id",    "type": "integer",           "nullable": false, "comment": "ユーザーID" },
+ *         { "name": "email", "type": "character varying", "nullable": false, "comment": "メールアドレス" }
  *       ]
  *     }
  *   ]
  * }
  * ```
  */
-router.get('/', async (_req: Request, res: Response): Promise<void> => {
+router.get('/', async (req: Request, res: Response): Promise<void> => {
+  const { dbConnectionId } = req.query
+
+  // dbConnectionId のバリデーション（必須）
+  if (!dbConnectionId || typeof dbConnectionId !== 'string' || dbConnectionId.trim() === '') {
+    res.status(400).json({
+      error: 'dbConnectionId クエリパラメータは必須です。',
+    })
+    return
+  }
+
+  // UUID v4 形式チェック（不正なIDを早期に弾く）
+  if (!uuidValidate(dbConnectionId)) {
+    res.status(400).json({
+      error: 'dbConnectionId の形式が不正です。UUID v4 形式で指定してください。',
+    })
+    return
+  }
+
   try {
-    const schema = await fetchSchema()
+    // fetchSchema() はキャッシュ優先で取得する
+    const schema = await fetchSchema(dbConnectionId)
     res.json(schema)
   } catch (error) {
+    // 接続先が見つからない場合は 404
+    if (error instanceof ConnectionNotFoundError) {
+      res.status(404).json({
+        error: `指定されたDB接続先が見つかりません: ${dbConnectionId}`,
+      })
+      return
+    }
+
+    // その他のエラー（DB接続エラー等）は 500
     // 接続情報（パスワード等）がレスポンスに含まれないよう、
-    // エラーメッセージのみを返す
+    // エラーメッセージのみを返す（詳細はサーバーログに記録）
     const message =
       error instanceof Error ? error.message : 'Unknown database error'
 
-    console.error('[GET /api/schema] DB error:', message)
+    console.error('[GET /api/schema] DB error:', message, 'dbConnectionId:', dbConnectionId)
 
     res.status(500).json({
       error: 'DB接続またはスキーマ取得に失敗しました',

--- a/output_system/backend/src/services/database.ts
+++ b/output_system/backend/src/services/database.ts
@@ -1,93 +1,84 @@
 /**
- * DB接続ファクトリ
+ * DB接続ファクトリ & クエリ実行サービス
  *
  * knex.js を使用して PostgreSQL / MySQL の両方に対応した
- * DB接続インスタンスをシングルトンで管理する。
+ * DB接続インスタンスを管理し、SELECT クエリを実行する。
  *
- * 接続情報は環境変数 (.env) から読み込む:
- *   DB_TYPE    : 'postgresql' または 'mysql'
- *   DB_HOST    : DBホスト
- *   DB_PORT    : DBポート (PostgreSQL: 5432, MySQL: 3306)
- *   DB_USER    : DBユーザー名（リードオンリーユーザーを推奨）
- *   DB_PASSWORD: DBパスワード
- *   DB_NAME    : 接続するデータベース名
+ * PBI #149 改修:
+ *   - executeQuery() が dbConnectionId を受け取り、connectionManager.getById() 経由で
+ *     動的にDB接続（以前は .env の固定DB接続のみだった）
+ *   - 接続プール: Map<dbConnectionId, Knex> で管理。切替時に前のプールは維持し、
+ *     同じ接続先への再リクエストは既存プールを再利用する（性能向上）
+ *   - destroyConnection() を公開し、接続先削除時にプールを破棄できるようにする
  *
  * セキュリティ注意事項:
  *   - DBユーザーはリードオンリー権限を推奨（SELECT のみ付与）
  *   - 接続情報はログに出力しない
+ *   - SQLバリデーション（sqlValidator）を二重防御として適用
  */
 
 import Knex, { Knex as KnexType } from 'knex'
 import { validate } from './sqlValidator'
+import { getById, ConnectionNotFoundError } from './connectionManager'
 
-/** サポートするDBタイプ */
-export type DbType = 'postgresql' | 'mysql'
-
-/** シングルトンのknexインスタンス */
-let dbInstance: KnexType | null = null
-
-/**
- * DB_TYPE 文字列を knex クライアント名に変換する
- *
- * @param dbType - 環境変数 DB_TYPE の値
- * @returns knex クライアント名
- * @throws DB_TYPE が不正な値の場合
- */
-export function resolveKnexClient(dbType: string): string {
-  switch (dbType) {
-    case 'postgresql':
-      return 'pg'
-    case 'mysql':
-      return 'mysql2'
-    default:
-      throw new Error(
-        `DB_TYPE="${dbType}" はサポートされていません。'postgresql' または 'mysql' を指定してください。`
-      )
-  }
-}
+// =============================================================================
+// 接続プール管理
+// =============================================================================
 
 /**
- * 環境変数からknex設定オブジェクトを構築する
+ * 接続プールのマップ
  *
- * @returns knex 初期化設定
- * @throws 必須の環境変数が未設定の場合
+ * キー: dbConnectionId（UUID）
+ * 値: knex インスタンス（接続プール込み）
+ *
+ * 各 dbConnectionId に対応する knex インスタンスをキャッシュし、
+ * 同じ接続先への繰り返しクエリで接続プールを再利用する。
+ *
+ * 接続先削除時は destroyConnection() でプールを破棄すること。
  */
-export function buildKnexConfig(): KnexType.Config {
-  const dbType = process.env.DB_TYPE
-  const host = process.env.DB_HOST
-  const port = process.env.DB_PORT
-  const user = process.env.DB_USER
-  const password = process.env.DB_PASSWORD
-  const database = process.env.DB_NAME
+const connectionPool = new Map<string, KnexType>()
 
-  // 必須環境変数のバリデーション
-  const missing: string[] = []
-  if (!dbType) missing.push('DB_TYPE')
-  if (!host) missing.push('DB_HOST')
-  if (!user) missing.push('DB_USER')
-  if (!database) missing.push('DB_NAME')
-
-  if (missing.length > 0) {
-    throw new Error(
-      `必須の環境変数が設定されていません: ${missing.join(', ')}\n` +
-        '.env ファイルに DB_TYPE, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME を設定してください。'
-    )
+/**
+ * 指定 dbConnectionId の knex インスタンスを取得する（プール再利用）
+ *
+ * プールに存在する場合はそのまま返す。存在しない場合は新規作成してプールに追加する。
+ * connectionManager.getById() で復号済みパスワードを取得して動的接続する。
+ *
+ * @param dbConnectionId - 接続先ID（UUID）
+ * @returns 初期化済みの knex インスタンス
+ * @throws ConnectionNotFoundError 接続先が見つからない場合
+ * @throws Error サポートされていない DB タイプの場合
+ */
+function getOrCreateConnection(dbConnectionId: string): KnexType {
+  // プールにインスタンスが存在する場合は再利用（接続コスト削減）
+  const existing = connectionPool.get(dbConnectionId)
+  if (existing) {
+    return existing
   }
 
-  const client = resolveKnexClient(dbType!)
+  // connectionManager.getById() で接続先情報（復号済みパスワード含む）を取得
+  const conn = getById(dbConnectionId)
+
+  // knex クライアント識別子のマッピング
+  const clientMap: Record<string, string> = {
+    mysql: 'mysql2',
+    postgresql: 'pg',
+  }
+
+  const client = clientMap[conn.dbType]
+  if (!client) {
+    throw new Error(`Unsupported DB type: ${conn.dbType}`)
+  }
 
   // デフォルトポート: PostgreSQL=5432, MySQL=3306
-  const defaultPort = dbType === 'postgresql' ? 5432 : 3306
-  const portNumber = port ? parseInt(port, 10) : defaultPort
-
-  return {
+  const knexInstance = Knex({
     client,
     connection: {
-      host: host!,
-      port: portNumber,
-      user: user!,
-      password: password || '',
-      database: database!,
+      host: conn.host,
+      port: conn.port,
+      user: conn.username,
+      password: conn.password,
+      database: conn.databaseName,
     },
     pool: {
       // 最小コネクション数: 0（アイドル時にコネクションを解放）
@@ -97,63 +88,51 @@ export function buildKnexConfig(): KnexType.Config {
     },
     // クエリのデバッグログを無効化（接続情報漏洩防止）
     debug: false,
+  })
+
+  // プールに追加（次回リクエストで再利用）
+  connectionPool.set(dbConnectionId, knexInstance)
+  console.info(`[database] Connection pool created for dbConnectionId: ${dbConnectionId}`)
+
+  return knexInstance
+}
+
+/**
+ * 指定 dbConnectionId の接続プールを破棄する
+ *
+ * 接続先削除時（DELETE /api/connections/:id）に呼び出して
+ * リソースリークを防止すること。
+ *
+ * @param dbConnectionId - 接続プールを破棄する接続先ID
+ */
+export async function destroyConnection(dbConnectionId: string): Promise<void> {
+  const knexInstance = connectionPool.get(dbConnectionId)
+  if (knexInstance) {
+    await knexInstance.destroy()
+    connectionPool.delete(dbConnectionId)
+    console.info(`[database] Connection pool destroyed for dbConnectionId: ${dbConnectionId}`)
   }
 }
 
 /**
- * knex インスタンスを取得する（シングルトン）
- *
- * 初回呼び出し時に環境変数から設定を読み込み、knex インスタンスを生成する。
- * 2回目以降は既存のインスタンスを返す。
- *
- * @returns 初期化済みの knex インスタンス
- * @throws 環境変数が未設定または不正な場合
- *
- * @example
- * ```typescript
- * const db = getDb()
- * const rows = await db.raw('SELECT 1')
- * ```
+ * 全接続プールを破棄する（アプリケーション終了時用）
  */
-export function getDb(): KnexType {
-  if (dbInstance) {
-    return dbInstance
+export async function destroyAllConnections(): Promise<void> {
+  const destroyPromises: Promise<void>[] = []
+  for (const [id, knexInstance] of connectionPool.entries()) {
+    destroyPromises.push(
+      knexInstance.destroy().then(() => {
+        console.info(`[database] Connection pool destroyed for dbConnectionId: ${id}`)
+      })
+    )
   }
-
-  const config = buildKnexConfig()
-  dbInstance = Knex(config)
-  return dbInstance
+  await Promise.all(destroyPromises)
+  connectionPool.clear()
 }
 
-/**
- * DB接続をクローズする
- *
- * アプリケーション終了時やテスト後に呼び出すこと。
- * コネクションプールを解放し、プロセスが正常終了できるようにする。
- *
- * @returns Promise<void>
- */
-export async function closeDb(): Promise<void> {
-  if (dbInstance) {
-    await dbInstance.destroy()
-    dbInstance = null
-  }
-}
-
-/**
- * テスト用: シングルトンインスタンスをリセットする
- *
- * ユニットテストでモックインスタンスを注入できるようにする。
- *
- * @param instance - 注入するknexインスタンス（省略時はnullにリセット）
- */
-export function resetDbInstance(instance: KnexType | null = null): void {
-  dbInstance = instance
-}
-
-// -------------------------------------------------------------------
+// =============================================================================
 // クエリ実行
-// -------------------------------------------------------------------
+// =============================================================================
 
 /**
  * クエリ実行結果の型
@@ -191,28 +170,30 @@ export interface QueryResult {
  * エラーハンドリング:
  *   - バリデーション失敗時は SqlValidationError をスロー
  *   - DB接続エラーや実行エラーはそのまま上位に伝播
+ *   - ConnectionNotFoundError は上位に伝播
  *
+ * @param dbConnectionId - 実行先DB接続先ID（UUID）
  * @param sql - 実行する SQL 文字列
- * @param db - 省略可能なknexインスタンス（省略時はシングルトンを使用、テスト用モック注入に利用）
  * @returns QueryResult - { columns: string[], rows: Record<string, unknown>[] }
  * @throws SqlValidationError - SQL がバリデーションを通過しなかった場合
+ * @throws ConnectionNotFoundError - 接続先が見つからない場合
  * @throws Error - DB 接続やクエリ実行に失敗した場合
  *
  * @example
  * ```typescript
  * // 正常系: SELECT文の実行
- * const result = await executeQuery('SELECT id, name FROM users LIMIT 10')
+ * const result = await executeQuery('uuid-xxx', 'SELECT id, name FROM users LIMIT 10')
  * console.log(result.columns) // ['id', 'name']
  * console.log(result.rows)    // [{ id: 1, name: 'Alice' }, ...]
  *
  * // 異常系: INSERT文は拒否される
- * await executeQuery("INSERT INTO users VALUES (1, 'Alice')")
+ * await executeQuery('uuid-xxx', "INSERT INTO users VALUES (1, 'Alice')")
  * // => throws SqlValidationError: 'INSERT' キーワードを含むSQLは実行できません
  * ```
  */
 export async function executeQuery(
+  dbConnectionId: string,
   sql: string,
-  db?: KnexType
 ): Promise<QueryResult> {
   // 二重防御: 実行直前にも validate() を呼ぶ
   // （呼び出し元が validate() を省略したケースでも確実にブロックする）
@@ -222,11 +203,12 @@ export async function executeQuery(
     throw new SqlValidationError(validation.reason ?? '不正なSQLです。')
   }
 
-  // DBインスタンスを取得（テスト用モックか、シングルトン）
-  const knex = db ?? getDb()
+  // 接続先IDからknexインスタンスを取得（プール再利用）
+  const knex = getOrCreateConnection(dbConnectionId)
 
-  // DB_TYPE を取得してクエリ実行方式を分岐
-  const dbType = process.env.DB_TYPE ?? 'postgresql'
+  // 接続先情報から DB タイプを取得（クエリ結果の形式判定に使用）
+  const conn = getById(dbConnectionId)
+  const dbType = conn.dbType
 
   // sanitizedSql（コメント除去・正規化済み SQL）を DB に渡す
   //
@@ -262,6 +244,10 @@ export async function executeQuery(
 
   return { columns, rows }
 }
+
+// =============================================================================
+// 正規化ユーティリティ
+// =============================================================================
 
 /**
  * クエリ結果の1行を JSON シリアライズ可能な値に正規化する
@@ -305,6 +291,10 @@ function normalizeValue(value: unknown): unknown {
   return value
 }
 
+// =============================================================================
+// エラークラス
+// =============================================================================
+
 /**
  * SQLバリデーションエラー
  *
@@ -314,7 +304,7 @@ function normalizeValue(value: unknown): unknown {
  * @example
  * ```typescript
  * try {
- *   await executeQuery('DROP TABLE users')
+ *   await executeQuery('uuid-xxx', 'DROP TABLE users')
  * } catch (err) {
  *   if (err instanceof SqlValidationError) {
  *     // 400 Bad Request
@@ -337,3 +327,6 @@ export class SqlValidationError extends Error {
     Object.setPrototypeOf(this, SqlValidationError.prototype)
   }
 }
+
+// Re-export ConnectionNotFoundError for convenience in route handlers
+export { ConnectionNotFoundError }

--- a/output_system/backend/src/services/schema.ts
+++ b/output_system/backend/src/services/schema.ts
@@ -1,8 +1,14 @@
 /**
  * スキーマ情報取得サービス
  *
- * PostgreSQL / MySQL の INFORMATION_SCHEMA からテーブル名・カラム名・型・NULL許容を取得する。
+ * PostgreSQL / MySQL の INFORMATION_SCHEMA からテーブル名・カラム名・型・NULL許容・
+ * テーブルコメント・カラムコメントを取得する。
  * DBごとのSQL差異を吸収し、統一されたレスポンス形式で返す。
+ *
+ * PBI #149 改修:
+ *   - dbConnectionId を受け取り、connectionManager.getById() 経由で動的に接続
+ *   - メモリキャッシュ: Map<dbConnectionId, SchemaInfo> でキャッシュを保持
+ *   - キャッシュ無効化: invalidateSchemaCache() を公開し、接続先更新・削除時に呼ぶ
  *
  * レスポンス形式は api.md の /api/schema と同一:
  * {
@@ -10,8 +16,9 @@
  *   tables: [
  *     {
  *       name: string,
+ *       comment: string | null,
  *       columns: [
- *         { name: string, type: string, nullable: boolean }
+ *         { name: string, type: string, nullable: boolean, comment: string | null }
  *       ]
  *     }
  *   ]
@@ -22,8 +29,8 @@
  *   - DBユーザーにはリードオンリー権限（SELECT のみ）を付与することを推奨
  */
 
-import { Knex } from 'knex'
-import { getDb } from './database'
+import Knex, { Knex as KnexType } from 'knex'
+import { getById, ConnectionNotFoundError } from './connectionManager'
 
 /** カラム情報 */
 export interface ColumnInfo {
@@ -58,18 +65,116 @@ interface InformationSchemaColumn {
   column_comment: string | null
 }
 
+// =============================================================================
+// メモリキャッシュ
+// =============================================================================
+
+/**
+ * スキーマ情報のメモリキャッシュ
+ *
+ * キー: dbConnectionId（UUID）
+ * 値: SchemaInfo（テーブル・カラム情報）
+ *
+ * DB選択時にキャッシュを活用することで、同じDBへの繰り返しスキーマ取得を回避する。
+ * サーバーが再起動するとキャッシュはクリアされる（揮発性キャッシュ）。
+ *
+ * 注意: 同期的な Map を使用しているため、マルチスレッド安全ではない。
+ * Node.js はシングルスレッドのため、実用上は問題なし。
+ */
+const schemaCache = new Map<string, SchemaInfo>()
+
+/**
+ * 指定 dbConnectionId のスキーマキャッシュを無効化（削除）する
+ *
+ * DB接続先の更新・削除時に呼び出すことで、古いスキーマ情報を使い続けるのを防ぐ。
+ * 接続先更新ルート（PUT /api/connections/:id）や
+ * 削除ルート（DELETE /api/connections/:id）から呼び出すこと。
+ *
+ * @param dbConnectionId - キャッシュを無効化する接続先ID
+ */
+export function invalidateSchemaCache(dbConnectionId: string): void {
+  if (schemaCache.has(dbConnectionId)) {
+    schemaCache.delete(dbConnectionId)
+    console.info(`[schema] Cache invalidated for dbConnectionId: ${dbConnectionId}`)
+  }
+}
+
+/**
+ * 全スキーマキャッシュをクリアする（テスト用・緊急用）
+ */
+export function clearAllSchemaCache(): void {
+  schemaCache.clear()
+  console.info('[schema] All schema cache cleared')
+}
+
+// =============================================================================
+// 動的接続ファクトリ
+// =============================================================================
+
+/**
+ * dbConnectionId から knex インスタンスを生成する
+ *
+ * connectionManager.getById() で接続先情報（復号済みパスワード含む）を取得し、
+ * 動的にknexインスタンスを生成して返す。
+ * このインスタンスはスキーマ取得後に破棄する（リソースリーク防止）。
+ *
+ * @param dbConnectionId - 接続先ID（UUID）
+ * @returns knexインスタンスと接続先のdatabaseName
+ * @throws ConnectionNotFoundError 接続先が見つからない場合
+ */
+function buildDynamicKnex(dbConnectionId: string): {
+  knex: KnexType
+  databaseName: string
+  dbType: string
+} {
+  // connectionManager.getById() で復号済みパスワードを取得
+  const conn = getById(dbConnectionId)
+
+  // knex クライアント識別子のマッピング
+  const clientMap: Record<string, string> = {
+    mysql: 'mysql2',
+    postgresql: 'pg',
+  }
+
+  const client = clientMap[conn.dbType]
+  if (!client) {
+    throw new Error(`Unsupported DB type: ${conn.dbType}`)
+  }
+
+  const knexInstance = Knex({
+    client,
+    connection: {
+      host: conn.host,
+      port: conn.port,
+      user: conn.username,
+      password: conn.password,
+      database: conn.databaseName,
+    },
+    // スキーマ取得専用のプール（最小限のコネクション）
+    pool: { min: 0, max: 2 },
+    debug: false,
+  })
+
+  return { knex: knexInstance, databaseName: conn.databaseName, dbType: conn.dbType }
+}
+
+// =============================================================================
+// スキーマ取得（DB種別ごとの実装）
+// =============================================================================
+
 /**
  * PostgreSQL 向け: カレントスキーマのテーブル・カラム情報を取得するSQLを実行する
  *
  * current_schema() を使用してデフォルトスキーマ（通常 'public'）のテーブルのみを取得。
  * information_schema の内部テーブル（pg_catalog等）は除外する。
+ * テーブルコメント・カラムコメントは pg_catalog の obj_description / col_description で取得。
  *
  * @param db - knexインスタンス
  * @param database - データベース名
  * @returns スキーマ情報
  */
 async function fetchSchemaPostgresql(
-  db: Knex,
+  db: KnexType,
   database: string
 ): Promise<SchemaInfo> {
   const rows = await db.raw<{ rows: InformationSchemaColumn[] }>(`
@@ -102,13 +207,15 @@ async function fetchSchemaPostgresql(
  *
  * DATABASE() を使用して現在のデータベースのテーブルのみを取得。
  * ビュー (VIEW) は除外し、BASE TABLE のみを対象とする。
+ * テーブルコメントは INFORMATION_SCHEMA.TABLES.TABLE_COMMENT、
+ * カラムコメントは INFORMATION_SCHEMA.COLUMNS.COLUMN_COMMENT で取得。
  *
  * @param db - knexインスタンス
  * @param database - データベース名
  * @returns スキーマ情報
  */
 async function fetchSchemaMysql(
-  db: Knex,
+  db: KnexType,
   database: string
 ): Promise<SchemaInfo> {
   const [rows] = await db.raw<[InformationSchemaColumn[]]>(`
@@ -130,6 +237,10 @@ async function fetchSchemaMysql(
 
   return buildSchemaInfo(database, rows)
 }
+
+// =============================================================================
+// データ変換
+// =============================================================================
 
 /**
  * INFORMATION_SCHEMA の行データを SchemaInfo 形式に変換する
@@ -169,38 +280,85 @@ export function buildSchemaInfo(
   return { database, tables }
 }
 
+// =============================================================================
+// 公開API
+// =============================================================================
+
 /**
- * 接続先DBのスキーマ情報を取得する
+ * 指定DB接続先のスキーマ情報を取得する（キャッシュ優先）
  *
- * DB_TYPE 環境変数に応じて PostgreSQL または MySQL 向けのSQLを実行し、
- * 統一されたレスポンス形式で返す。
+ * キャッシュに該当 dbConnectionId のスキーマが存在する場合は即返却する。
+ * ない場合は動的にDB接続してスキーマを取得し、キャッシュに保存してから返す。
  *
+ * DB_TYPE（dbType）は接続先設定から自動取得する。
  * このサービスはリードオンリー操作のみを行う（SELECT のみ）。
- * DBユーザーには SELECT 権限のみを付与したリードオンリーユーザーの使用を推奨する。
  *
- * @param db - knexインスタンス（省略時は getDb() を使用）
+ * @param dbConnectionId - DB接続先ID（UUID）。connectionManager に登録済みのもの。
  * @returns スキーマ情報
- * @throws DB接続失敗またはクエリエラー
+ * @throws ConnectionNotFoundError 接続先が見つからない場合
+ * @throws Error DB接続失敗またはクエリエラー
  *
  * @example
  * ```typescript
- * const schema = await fetchSchema()
+ * // キャッシュがある場合は即返却（2回目以降は高速）
+ * const schema = await fetchSchema('uuid-of-connection')
  * console.log(schema.tables.map(t => t.name))
  * ```
  */
-export async function fetchSchema(db?: Knex): Promise<SchemaInfo> {
-  const knex = db ?? getDb()
-  const dbType = process.env.DB_TYPE ?? ''
-  const database = process.env.DB_NAME ?? ''
+export async function fetchSchema(dbConnectionId: string): Promise<SchemaInfo> {
+  // キャッシュから返せる場合は即返却（DB接続コストを削減）
+  const cached = schemaCache.get(dbConnectionId)
+  if (cached) {
+    console.info(`[schema] Cache hit for dbConnectionId: ${dbConnectionId}`)
+    return cached
+  }
 
-  switch (dbType) {
-    case 'postgresql':
-      return fetchSchemaPostgresql(knex, database)
-    case 'mysql':
-      return fetchSchemaMysql(knex, database)
-    default:
-      throw new Error(
-        `DB_TYPE="${dbType}" はサポートされていません。'postgresql' または 'mysql' を指定してください。`
-      )
+  console.info(`[schema] Cache miss, fetching from DB for dbConnectionId: ${dbConnectionId}`)
+
+  // 動的knexインスタンスを生成
+  let knexInstance: KnexType | null = null
+  try {
+    const { knex, databaseName, dbType } = buildDynamicKnex(dbConnectionId)
+    knexInstance = knex
+
+    // DB種別に応じてスキーマ取得SQLを実行
+    let schemaInfo: SchemaInfo
+    switch (dbType) {
+      case 'postgresql':
+        schemaInfo = await fetchSchemaPostgresql(knexInstance, databaseName)
+        break
+      case 'mysql':
+        schemaInfo = await fetchSchemaMysql(knexInstance, databaseName)
+        break
+      default:
+        throw new Error(
+          `DB_TYPE="${dbType}" はサポートされていません。'postgresql' または 'mysql' を指定してください。`
+        )
+    }
+
+    // キャッシュに保存（以降のリクエストはキャッシュから返す）
+    schemaCache.set(dbConnectionId, schemaInfo)
+    console.info(
+      `[schema] Schema cached for dbConnectionId: ${dbConnectionId} (${schemaInfo.tables.length} tables)`
+    )
+
+    return schemaInfo
+  } finally {
+    // スキーマ取得後は動的knexインスタンスを破棄してリソースをリリース
+    if (knexInstance) {
+      await knexInstance.destroy()
+    }
   }
 }
+
+// =============================================================================
+// 後方互換性（.envの固定DB接続向け。既存コードとの互換を保つため残存）
+// =============================================================================
+
+// NOTE: 以前の fetchSchema() は .env の固定DB接続を使用していた。
+// PBI #149 改修後は dbConnectionId 必須の新APIに移行したため、
+// 固定接続版は削除した。呼び出し元（routes/schema.ts, routes/chat.ts）も
+// dbConnectionId を必須で渡すよう改修すること。
+
+// Re-export ConnectionNotFoundError for use in routes
+export { ConnectionNotFoundError }

--- a/output_system/frontend/src/App.tsx
+++ b/output_system/frontend/src/App.tsx
@@ -4,7 +4,7 @@
  * アプリケーション全体のレイアウトを定義する最上位コンポーネント。
  *
  * レイアウト構成（screens.md ワイヤーフレーム準拠）:
- * - Header: DataAgentロゴ + DB選択ドロップダウン（管理ボタン付き） + 新しい会話ボタン
+ * - Header: DataAgentロゴ + DB選択ドロップダウン + 管理ボタン + 新しい会話ボタン
  * - Content:
  *   - Sidebar（左 250px）: 検索ボックス + 履歴一覧
  *   - Main（残り幅）: ChatContainer
@@ -20,6 +20,12 @@
  * - ヘッダーに「管理」ボタンを追加（DB管理モーダルを開く）
  * - DbManagementModal コンポーネントを統合
  * - isDbModalOpen state でモーダルの開閉を管理
+ *
+ * PBI #149 更新（自然言語SQL生成・実行）:
+ * - ヘッダーに DB接続先選択ドロップダウンを追加
+ * - selectedDbConnectionId state で選択中のDB接続先IDを管理
+ * - send() に dbConnectionId を渡すよう ChatContainer の onSend を更新
+ * - 接続先が未選択の場合はチャット入力を無効化
  */
 
 import { useState, useCallback, useEffect, useRef, type FC } from 'react'
@@ -28,12 +34,14 @@ import Sidebar from './components/Sidebar/Sidebar'
 import DbManagementModal from './components/DbManagement/DbManagementModal'
 import { useChat } from './hooks/useChat'
 import { useHistory } from './hooks/useHistory'
+import { useDbConnections } from './hooks/useDbConnections'
 
 /**
  * DataAgent アプリケーション ルートコンポーネント
  *
  * ヘッダー + サイドバー + チャットエリアの3カラムレイアウトを構成する。
  * useChat と useHistory を統合し、会話選択・削除・リフレッシュを管理する。
+ * useDbConnections でDB接続先一覧を管理し、選択中のDB接続先をチャットに渡す。
  */
 const App: FC = () => {
   // チャット状態（メッセージ、ローディング、conversationId）
@@ -55,14 +63,49 @@ const App: FC = () => {
     loadConversation,
   } = useHistory()
 
+  // DB接続先一覧（PBI #149 追加: 選択中DB接続先の管理）
+  const { connections, fetchConnections } = useDbConnections()
+
   // DB管理モーダルの開閉状態（PBI #148 追加）
   const [isDbModalOpen, setIsDbModalOpen] = useState(false)
+
+  /**
+   * 選択中のDB接続先ID（PBI #149 追加）
+   *
+   * チャット送信時にバックエンドへ渡し、スキーマ取得・クエリ実行先を指定する。
+   * null = 未選択（チャット入力が無効）
+   */
+  const [selectedDbConnectionId, setSelectedDbConnectionId] = useState<string | null>(null)
 
   /**
    * 前回の isLoading 値を保持するref
    * isLoading が true → false に変わった（送信完了）タイミングを検出するために使用
    */
   const prevIsLoadingRef = useRef<boolean>(false)
+
+  /**
+   * 接続先一覧が変化したとき、選択中IDが存在しない場合はデフォルト選択する
+   *
+   * isLastUsed = true の接続先を優先し、なければ先頭を選択する。
+   * ただし既に有効な選択がある場合は変更しない。
+   */
+  useEffect(() => {
+    if (connections.length === 0) {
+      // 接続先がなくなった場合は選択解除
+      setSelectedDbConnectionId(null)
+      return
+    }
+
+    // 既に有効な選択がある場合はそのまま維持
+    if (selectedDbConnectionId && connections.some((c) => c.id === selectedDbConnectionId)) {
+      return
+    }
+
+    // isLastUsed = true の接続先を優先してデフォルト選択
+    const lastUsed = connections.find((c) => c.isLastUsed)
+    const defaultConnection = lastUsed ?? connections[0]
+    setSelectedDbConnectionId(defaultConnection.id)
+  }, [connections, selectedDbConnectionId])
 
   /**
    * チャット送信完了後に履歴を自動リフレッシュする
@@ -144,9 +187,44 @@ const App: FC = () => {
     }
   }, [conversations, conversationId, clearMessages])
 
+  /**
+   * DB管理モーダルを閉じるハンドラ（PBI #149 追加: モーダル閉時に接続先一覧を再取得）
+   *
+   * モーダルで接続先の追加・更新・削除が行われた可能性があるため、
+   * モーダルを閉じるたびに接続先一覧を再取得して最新状態に保つ。
+   */
+  const handleDbModalClose = useCallback(async () => {
+    setIsDbModalOpen(false)
+    // モーダル閉時に接続先一覧を再取得（追加・更新・削除が反映されるよう）
+    await fetchConnections()
+  }, [fetchConnections])
+
+  /**
+   * チャット送信ハンドラ（PBI #149 追加: dbConnectionId を含めて送信）
+   *
+   * ChatContainer の onSend は (message: string) のシグネチャだが、
+   * useChat.send() は (message: string, dbConnectionId: string) を必要とする。
+   * ここでラップして selectedDbConnectionId を注入する。
+   *
+   * dbConnectionId が未選択の場合は送信しない（UI側で入力を無効化済みだが念のため）。
+   *
+   * @param message - ユーザーが入力した質問テキスト
+   */
+  const handleSend = useCallback(
+    async (message: string): Promise<void> => {
+      if (!selectedDbConnectionId) {
+        // DB接続先が未選択の場合は送信しない
+        console.warn('[App] Cannot send message: no DB connection selected')
+        return
+      }
+      await send(message, selectedDbConnectionId)
+    },
+    [send, selectedDbConnectionId],
+  )
+
   return (
     <div className="app-container">
-      {/* ヘッダー: DataAgentロゴ + DB管理ボタン + 新しい会話ボタン */}
+      {/* ヘッダー: DataAgentロゴ + DB接続先選択 + DB管理ボタン + 新しい会話ボタン */}
       <header className="app-header">
         <div className="app-header__left">
           {/* DataAgent ロゴ */}
@@ -155,6 +233,28 @@ const App: FC = () => {
           <h1 className="app-header__title">DataAgent</h1>
         </div>
         <div className="app-header__right">
+          {/* DB接続先選択ドロップダウン（PBI #149 追加） */}
+          {connections.length > 0 ? (
+            <select
+              className="app-header__db-select"
+              value={selectedDbConnectionId ?? ''}
+              onChange={(e) => setSelectedDbConnectionId(e.target.value || null)}
+              aria-label="DB接続先を選択"
+              title="チャットで使用するDB接続先を選択"
+            >
+              {connections.map((conn) => (
+                <option key={conn.id} value={conn.id}>
+                  {conn.name} ({conn.dbType})
+                </option>
+              ))}
+            </select>
+          ) : (
+            /* 接続先が未登録の場合は案内テキストを表示 */
+            <span className="app-header__no-db-notice" role="status">
+              DB接続先を登録してください
+            </span>
+          )}
+
           {/* DB管理ボタン（PBI #148 追加: DB接続先管理モーダルを開く） */}
           <button
             className="app-header__manage-btn"
@@ -180,7 +280,7 @@ const App: FC = () => {
       {/* DB接続先管理モーダル（PBI #148 追加） */}
       <DbManagementModal
         isOpen={isDbModalOpen}
-        onClose={() => setIsDbModalOpen(false)}
+        onClose={handleDbModalClose}
       />
 
       {/* メインコンテンツ領域（サイドバー + チャットエリア） */}
@@ -201,7 +301,8 @@ const App: FC = () => {
           <ChatContainer
             messages={messages}
             isLoading={isLoading}
-            onSend={send}
+            onSend={handleSend}
+            isDbConnectionSelected={!!selectedDbConnectionId}
           />
         </main>
       </div>

--- a/output_system/frontend/src/components/Chat/ChatContainer.tsx
+++ b/output_system/frontend/src/components/Chat/ChatContainer.tsx
@@ -24,14 +24,18 @@ import Loading from '../common/Loading'
 /**
  * ChatContainer コンポーネントの Props
  *
- * @property messages   - 現在の会話のメッセージ一覧（App.tsx の useChat から渡す）
- * @property isLoading  - LLMの応答待ち中かどうか
- * @property onSend     - メッセージ送信ハンドラ
+ * @property messages              - 現在の会話のメッセージ一覧（App.tsx の useChat から渡す）
+ * @property isLoading             - LLMの応答待ち中かどうか
+ * @property onSend                - メッセージ送信ハンドラ
+ * @property isDbConnectionSelected - DB接続先が選択されているかどうか（PBI #149 追加）
+ *                                    false の場合はチャット入力を無効化する
  */
 interface ChatContainerProps {
   messages: ChatMessageType[]
   isLoading: boolean
   onSend: (message: string) => Promise<void>
+  /** DB接続先が選択されているかどうか（false = 未選択でチャット入力を無効化） */
+  isDbConnectionSelected?: boolean
 }
 
 /**
@@ -42,7 +46,12 @@ interface ChatContainerProps {
  *
  * @param props - ChatContainerProps
  */
-const ChatContainer: FC<ChatContainerProps> = ({ messages, isLoading, onSend }) => {
+const ChatContainer: FC<ChatContainerProps> = ({
+  messages,
+  isLoading,
+  onSend,
+  isDbConnectionSelected = true,
+}) => {
   // チャットエリアの最下部へのスクロール用 ref
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
@@ -72,19 +81,30 @@ const ChatContainer: FC<ChatContainerProps> = ({ messages, isLoading, onSend }) 
           <div className="chat-welcome">
             <div className="chat-welcome__icon" aria-hidden="true">🤖</div>
             <h2 className="chat-welcome__title">DataAgent へようこそ</h2>
-            <p className="chat-welcome__description">
-              自然言語でデータベースに質問できます。
-              <br />
-              SQLの知識がなくてもデータ分析が可能です。
-            </p>
-            <div className="chat-welcome__examples">
-              <p className="chat-welcome__examples-label">質問の例:</p>
-              <ul className="chat-welcome__examples-list">
-                <li>今月の売上トップ10を教えて</li>
-                <li>部門別の従業員数はいくつですか？</li>
-                <li>先週の注文数を日別に集計してください</li>
-              </ul>
-            </div>
+            {isDbConnectionSelected ? (
+              <>
+                <p className="chat-welcome__description">
+                  自然言語でデータベースに質問できます。
+                  <br />
+                  SQLの知識がなくてもデータ分析が可能です。
+                </p>
+                <div className="chat-welcome__examples">
+                  <p className="chat-welcome__examples-label">質問の例:</p>
+                  <ul className="chat-welcome__examples-list">
+                    <li>今月の売上トップ10を教えて</li>
+                    <li>部門別の従業員数はいくつですか？</li>
+                    <li>先週の注文数を日別に集計してください</li>
+                  </ul>
+                </div>
+              </>
+            ) : (
+              /* DB接続先未選択時の案内 */
+              <p className="chat-welcome__description" role="alert">
+                上部の「管理」ボタンからDB接続先を登録し、
+                <br />
+                接続先を選択してからチャットを開始してください。
+              </p>
+            )}
           </div>
         )}
 
@@ -106,7 +126,18 @@ const ChatContainer: FC<ChatContainerProps> = ({ messages, isLoading, onSend }) 
 
       {/* 入力エリア（下部固定） */}
       <div className="chat-input-wrapper">
-        <ChatInput onSend={onSend} isLoading={isLoading} />
+        {/* isDbConnectionSelected が false の場合は入力を無効化（PBI #149 追加） */}
+        <ChatInput
+          onSend={onSend}
+          isLoading={isLoading}
+          disabled={!isDbConnectionSelected}
+        />
+        {/* DB接続先未選択時の警告メッセージ */}
+        {!isDbConnectionSelected && (
+          <p className="chat-input-no-db-notice" role="alert" aria-live="polite">
+            DB接続先が選択されていません。ヘッダーから接続先を選択してください。
+          </p>
+        )}
       </div>
     </div>
   )

--- a/output_system/frontend/src/hooks/useChat.ts
+++ b/output_system/frontend/src/hooks/useChat.ts
@@ -12,14 +12,19 @@
  * - conversationId を管理し、継続会話のリクエストに含める（PBI #13 Epic 4）
  * - 履歴復元は restoreConversation() ラッパー経由で行い、内部 setState を外部に公開しない
  *
+ * PBI #149 更新:
+ * - send() に dbConnectionId パラメータを追加（選択中のDB接続先ID）
+ * - POST /api/chat のリクエストボディに dbConnectionId を含める
+ *
  * SSEイベント仕様（api.md / chat.ts 準拠）:
+ *   event: conversation - 会話ID通知（conversationId プロパティ）※PBI #13 追加
  *   event: message      - テキストチャンク（chunk プロパティ）
  *   event: sql          - 生成SQL（sql プロパティ）
  *   event: chart_type   - グラフ種類（chartType プロパティ）
  *   event: result       - クエリ結果（columns / rows / chartType プロパティ）
+ *   event: analysis     - AI分析コメントチャンク（chunk プロパティ）
  *   event: error        - エラーメッセージ（message プロパティ）
  *   event: done         - ストリーム終了（データなし）
- *   event: conversation - 会話ID通知（conversationId プロパティ）※PBI #13 追加
  */
 
 import { useState, useCallback, useRef } from 'react'
@@ -165,12 +170,19 @@ export function useChat(): UseChatReturn {
    * 5. done イベントまたはエラーで isLoading を false に
    *
    * @param message - ユーザーが入力した質問テキスト
+   * @param dbConnectionId - 選択中のDB接続先ID（UUID）。PBI #149 で追加。
    */
   const send = useCallback(
-    async (message: string) => {
+    async (message: string, dbConnectionId: string) => {
       // 空メッセージは送信しない
       const trimmed = message.trim()
       if (!trimmed) return
+
+      // dbConnectionId が未設定の場合は送信しない（UI側でバリデーション済みのはずだが念のため）
+      if (!dbConnectionId) {
+        console.warn('[useChat] dbConnectionId is required but not provided')
+        return
+      }
 
       // 前のリクエストが進行中であれば中断
       if (abortControllerRef.current) {
@@ -193,8 +205,12 @@ export function useChat(): UseChatReturn {
 
       try {
         // SSEストリームを購読
-        // conversationId が存在する場合はリクエストボディに含めて継続会話を示す
-        const requestBody: Record<string, unknown> = { message: trimmed }
+        // dbConnectionId（PBI #149 追加）と conversationId をリクエストボディに含める
+        const requestBody: Record<string, unknown> = {
+          message: trimmed,
+          // 選択中のDB接続先ID（必須: バックエンドがスキーマ取得・クエリ実行に使用）
+          dbConnectionId,
+        }
         // 現在の conversationId を閉じ込めるため、送信前に変数に取得する
         // （useState の値は非同期で古くなる場合があるため、ref を使う方が安全だが、
         //   SSE で conversationId を受け取るまで変化しないため useState で十分）

--- a/output_system/frontend/src/styles/global.css
+++ b/output_system/frontend/src/styles/global.css
@@ -1719,6 +1719,61 @@ body {
   opacity: 1;
 }
 
+/* =============================================================================
+ * DB接続先セレクター（ヘッダー）
+ * PBI #149 追加
+ * ============================================================================= */
+
+/**
+ * DB接続先選択ドロップダウン（ヘッダー右側）
+ * チャット送信時に使用するDB接続先を選択するためのセレクト要素
+ */
+.app-header__db-select {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  white-space: nowrap;
+  /* ドロップダウン矢印の色を白に調整 */
+  appearance: auto;
+  /* 最大幅を設定して長い接続名も収まるよう */
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-header__db-select:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-header__db-select option {
+  /* オプション要素はブラウザのデフォルトスタイルを使用 */
+  background-color: var(--color-primary);
+  color: white;
+}
+
+/* DB接続先未登録時の通知テキスト */
+.app-header__no-db-notice {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.8rem;
+  font-style: italic;
+  white-space: nowrap;
+}
+
+/* DB接続先未選択時のチャット入力無効化通知 */
+.chat-input-no-db-notice {
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  font-style: italic;
+  margin-top: var(--spacing-xs);
+  text-align: center;
+}
+
 /* ローディングスピナー（DB接続先一覧のローディング表示用） */
 .loading-spinner {
   display: inline-block;

--- a/output_system/frontend/src/types/index.ts
+++ b/output_system/frontend/src/types/index.ts
@@ -230,6 +230,9 @@ export interface UseDbConnectionsReturn {
  * - conversationId を追加（現在の会話ID。新規会話時は null）
  * - restoreConversation を追加（履歴復元用ラッパー関数）
  *
+ * PBI #149 更新:
+ * - send() が dbConnectionId を受け取るよう変更（選択中のDB接続先ID）
+ *
  * 設計原則:
  * - React.Dispatch 等の内部型は公開インターフェースに露出させない
  * - 外部から状態を変更する場合は意図が明確なラッパー関数（restoreConversation）を使用する
@@ -237,7 +240,7 @@ export interface UseDbConnectionsReturn {
  * @property messages             - 現在の会話のメッセージ一覧
  * @property isLoading            - LLMの応答待ち中かどうか（送信中〜done受信まで）
  * @property conversationId       - 現在の会話ID（バックエンドから受け取る。null = 新規会話）
- * @property send                 - 質問を送信する関数
+ * @property send                 - 質問を送信する関数（dbConnectionId が必須）
  * @property clearMessages        - 会話をリセットする関数（conversationId もリセット）
  * @property restoreConversation  - 履歴から会話を復元する関数（messages と conversationId を一括設定）
  */
@@ -245,7 +248,9 @@ export interface UseChatReturn {
   messages: ChatMessage[]
   isLoading: boolean
   conversationId: string | null
-  send: (message: string) => Promise<void>
+  /** @param message - ユーザーの質問テキスト */
+  /** @param dbConnectionId - 選択中のDB接続先ID（UUID）。必須。 */
+  send: (message: string, dbConnectionId: string) => Promise<void>
   clearMessages: () => void
   restoreConversation: (id: string, loadedMessages: ChatMessage[]) => void
 }

--- a/output_system/test/unit/chat.test.ts
+++ b/output_system/test/unit/chat.test.ts
@@ -230,21 +230,26 @@ function setupErrorLlmMock(error: Error): void {
 // supertestでSSEレスポンスを取得するヘルパー
 // ---------------------------------------------------------------------------
 
+/** テスト用ダミーのDB接続先ID（UUID v4形式） */
+const TEST_DB_CONNECTION_ID = '550e8400-e29b-41d4-a716-446655440000'
+
 /**
  * supertestでSSEストリーミングレスポンスを取得する
  *
  * @param app - Expressアプリ
  * @param message - 送信するメッセージ
+ * @param dbConnectionId - DB接続先ID（デフォルト: TEST_DB_CONNECTION_ID）
  * @returns { status: number; text: string }
  */
 async function sendChatRequest(
   app: express.Express,
-  message: string
+  message: string,
+  dbConnectionId: string = TEST_DB_CONNECTION_ID
 ): Promise<{ status: number; text: string }> {
   return new Promise((resolve, reject) => {
     const req = request(app)
       .post('/api/chat')
-      .send({ message })
+      .send({ message, dbConnectionId })
       .set('Accept', 'text/event-stream')
 
     let responseText = ''
@@ -640,7 +645,7 @@ describe('POST /api/chat', () => {
     // Act
     const res = await request(app)
       .post('/api/chat')
-      .send({ message: 'テスト', conversationId: longId })
+      .send({ message: 'テスト', conversationId: longId, dbConnectionId: TEST_DB_CONNECTION_ID })
 
     // Assert
     expect(res.status).toBe(400)
@@ -668,7 +673,7 @@ describe('POST /api/chat', () => {
     const res2 = await new Promise<{ status: number; text: string }>((resolve, reject) => {
       const req = request(app)
         .post('/api/chat')
-        .send({ message: 'テスト', conversationId: 'not-a-valid-uuid' })
+        .send({ message: 'テスト', conversationId: 'not-a-valid-uuid', dbConnectionId: TEST_DB_CONNECTION_ID })
         .set('Accept', 'text/event-stream')
 
       let responseText = ''
@@ -715,7 +720,7 @@ describe('POST /api/chat', () => {
     const res = await new Promise<{ status: number; text: string }>((resolve, reject) => {
       const req = request(app)
         .post('/api/chat')
-        .send({ message: 'テスト', conversationId: validUuid })
+        .send({ message: 'テスト', conversationId: validUuid, dbConnectionId: TEST_DB_CONNECTION_ID })
         .set('Accept', 'text/event-stream')
 
       let responseText = ''

--- a/output_system/test/unit/database.test.ts
+++ b/output_system/test/unit/database.test.ts
@@ -2,13 +2,14 @@
  * 【モジュール】backend/src/services/database.ts
  * DB接続ファクトリ・クエリ実行サービスのユニットテスト
  *
- * テスト対象:
- *   - resolveKnexClient(): DB_TYPE → knex クライアント名変換
- *   - buildKnexConfig(): 環境変数から knex 設定を構築
- *   - getDb(): シングルトンインスタンスの取得
- *   - resetDbInstance(): テスト用リセット
- *   - executeQuery(): SQL実行と結果の正規化
- *   - SqlValidationError: カスタムエラークラス
+ * PBI #149 改修後のテスト:
+ *   - executeQuery(): dbConnectionId + SQL を引数に取り、connectionManager 経由で動的接続
+ *   - SqlValidationError: カスタムエラークラスの instanceof チェック
+ *   - destroyConnection(): 接続プール破棄（副作用なしで完了すること）
+ *
+ * テスト方針:
+ *   - connectionManager.getById() をモックして実際のDB接続を行わない
+ *   - sqlValidator.validate() をモックしてバリデーションロジックを独立してテスト
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -18,203 +19,75 @@ vi.mock('../../backend/src/services/sqlValidator', () => ({
   validate: vi.fn(),
 }))
 
+// connectionManager モジュールをモック（実DBへの接続を回避）
+vi.mock('../../backend/src/services/connectionManager', () => ({
+  getById: vi.fn(),
+  ConnectionNotFoundError: class ConnectionNotFoundError extends Error {
+    constructor(id: string) {
+      super(`DB connection with id '${id}' not found.`)
+      this.name = 'ConnectionNotFoundError'
+    }
+  },
+}))
+
+// knex モジュールをモック（実DB接続を回避）
+vi.mock('knex', () => {
+  return {
+    default: vi.fn(() => ({
+      raw: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })),
+  }
+})
+
 import {
-  resolveKnexClient,
-  buildKnexConfig,
-  getDb,
-  resetDbInstance,
-  closeDb,
   executeQuery,
+  destroyConnection,
+  destroyAllConnections,
   SqlValidationError,
 } from '../../backend/src/services/database'
 import { validate } from '../../backend/src/services/sqlValidator'
+import { getById } from '../../backend/src/services/connectionManager'
+import Knex from 'knex'
 
 // ---------------------------------------------------------------------------
-// resolveKnexClient のテスト
+// テストセットアップ: 各テスト前に接続プールをクリア
 // ---------------------------------------------------------------------------
-
-describe('resolveKnexClient', () => {
-  /**
-   * 【テスト対象】resolveKnexClient
-   * 【テスト内容】'postgresql' を渡した場合
-   * 【期待結果】'pg' が返ること
-   */
-  it('should return "pg" for "postgresql"', () => {
-    expect(resolveKnexClient('postgresql')).toBe('pg')
-  })
-
-  /**
-   * 【テスト対象】resolveKnexClient
-   * 【テスト内容】'mysql' を渡した場合
-   * 【期待結果】'mysql2' が返ること
-   */
-  it('should return "mysql2" for "mysql"', () => {
-    expect(resolveKnexClient('mysql')).toBe('mysql2')
-  })
-
-  /**
-   * 【テスト対象】resolveKnexClient
-   * 【テスト内容】サポート外の値を渡した場合
-   * 【期待結果】エラーがスローされること
-   */
-  it('should throw error for unsupported DB type', () => {
-    expect(() => resolveKnexClient('oracle')).toThrow('oracle')
-  })
-})
+// database.ts はモジュールレベルの connectionPool (Map) を持つ。
+// テスト間の独立性を確保するため、各テスト後に destroyAllConnections() で
+// プールをクリアする。これにより各テストで新しい Knex モックが適用される。
 
 // ---------------------------------------------------------------------------
-// buildKnexConfig のテスト
+// テストヘルパー
 // ---------------------------------------------------------------------------
 
-describe('buildKnexConfig', () => {
-  const originalEnv = process.env
-
-  beforeEach(() => {
-    process.env = { ...originalEnv }
-  })
-
-  afterEach(() => {
-    process.env = originalEnv
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】必須環境変数がすべて設定されている場合
-   * 【期待結果】正しい knex 設定オブジェクトが返ること
-   */
-  it('should build config from environment variables', () => {
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_HOST = 'localhost'
-    process.env.DB_PORT = '5432'
-    process.env.DB_USER = 'testuser'
-    process.env.DB_PASSWORD = 'testpass'
-    process.env.DB_NAME = 'testdb'
-
-    const config = buildKnexConfig()
-
-    expect(config.client).toBe('pg')
-    expect((config.connection as Record<string, unknown>).host).toBe('localhost')
-    expect((config.connection as Record<string, unknown>).port).toBe(5432)
-    expect((config.connection as Record<string, unknown>).user).toBe('testuser')
-    expect((config.connection as Record<string, unknown>).password).toBe('testpass')
-    expect((config.connection as Record<string, unknown>).database).toBe('testdb')
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】DB_PORT が未設定の場合にデフォルトポートが使われること
-   * 【期待結果】PostgreSQLの場合は5432が使われること
-   */
-  it('should use default port 5432 for postgresql when DB_PORT is not set', () => {
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_HOST = 'localhost'
-    delete process.env.DB_PORT
-    process.env.DB_USER = 'testuser'
-    process.env.DB_NAME = 'testdb'
-
-    const config = buildKnexConfig()
-    expect((config.connection as Record<string, unknown>).port).toBe(5432)
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】MySQLでDB_PORT未設定の場合にデフォルトポート3306が使われること
-   * 【期待結果】ポート3306が返ること
-   */
-  it('should use default port 3306 for mysql when DB_PORT is not set', () => {
-    process.env.DB_TYPE = 'mysql'
-    process.env.DB_HOST = 'localhost'
-    delete process.env.DB_PORT
-    process.env.DB_USER = 'testuser'
-    process.env.DB_NAME = 'testdb'
-
-    const config = buildKnexConfig()
-    expect((config.connection as Record<string, unknown>).port).toBe(3306)
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】DB_PASSWORD が未設定の場合に空文字が使われること
-   * 【期待結果】password が空文字列であること
-   */
-  it('should use empty string for password when DB_PASSWORD is not set', () => {
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_HOST = 'localhost'
-    process.env.DB_USER = 'testuser'
-    process.env.DB_NAME = 'testdb'
-    delete process.env.DB_PASSWORD
-
-    const config = buildKnexConfig()
-    expect((config.connection as Record<string, unknown>).password).toBe('')
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】必須環境変数が欠落している場合
-   * 【期待結果】エラーがスローされること
-   */
-  it('should throw error when required env variables are missing', () => {
-    delete process.env.DB_TYPE
-    delete process.env.DB_HOST
-    delete process.env.DB_USER
-    delete process.env.DB_NAME
-
-    expect(() => buildKnexConfig()).toThrow('DB_TYPE')
-  })
-
-  /**
-   * 【テスト対象】buildKnexConfig
-   * 【テスト内容】DB_HOST のみ欠落している場合
-   * 【期待結果】エラーメッセージに DB_HOST が含まれること
-   */
-  it('should include missing variable name in error message', () => {
-    process.env.DB_TYPE = 'postgresql'
-    delete process.env.DB_HOST
-    process.env.DB_USER = 'testuser'
-    process.env.DB_NAME = 'testdb'
-
-    expect(() => buildKnexConfig()).toThrow('DB_HOST')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// getDb / resetDbInstance / closeDb のテスト
-// ---------------------------------------------------------------------------
-
-describe('getDb / resetDbInstance / closeDb', () => {
-  const originalEnv = process.env
-
-  beforeEach(() => {
-    process.env = { ...originalEnv }
-    resetDbInstance(null)
-  })
-
-  afterEach(() => {
-    resetDbInstance(null)
-    process.env = originalEnv
-  })
-
-  /**
-   * 【テスト対象】resetDbInstance
-   * 【テスト内容】モックインスタンスを注入した場合にそれが返ること
-   * 【期待結果】注入したインスタンスが getDb() から返ること
-   */
-  it('should return injected instance after resetDbInstance', () => {
-    const mockInstance = { mock: true } as any
-    resetDbInstance(mockInstance)
-    expect(getDb()).toBe(mockInstance)
-  })
-
-  /**
-   * 【テスト対象】closeDb
-   * 【テスト内容】インスタンスが null の場合にエラーなく完了すること
-   * 【期待結果】エラーがスローされないこと
-   */
-  it('should not throw when closing with no instance', async () => {
-    resetDbInstance(null)
-    await expect(closeDb()).resolves.not.toThrow()
-  })
-})
+/**
+ * DB接続先モックオブジェクトを生成するヘルパー
+ */
+function createMockConnection(overrides: Partial<{
+  id: string
+  dbType: 'mysql' | 'postgresql'
+  host: string
+  port: number
+  username: string
+  password: string
+  databaseName: string
+}> = {}) {
+  return {
+    id: 'test-connection-id',
+    name: 'テストDB',
+    dbType: 'postgresql' as const,
+    host: 'localhost',
+    port: 5432,
+    username: 'testuser',
+    password: 'testpass',
+    databaseName: 'testdb',
+    isLastUsed: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
 
 // ---------------------------------------------------------------------------
 // executeQuery のテスト
@@ -228,19 +101,22 @@ describe('executeQuery', () => {
     vi.clearAllMocks()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     process.env = originalEnv
+    // 接続プールをクリア（テスト間の独立性確保: 各テストで新しい Knex モックを適用）
+    // afterEach でクリアすることで、次のテストが始まる前に必ず空の状態になる
+    await destroyAllConnections()
   })
 
   /**
    * 【テスト対象】executeQuery
-   * 【テスト内容】バリデーション失敗時に SqlValidationError がスローされること
-   * 【期待結果】SqlValidationError がスローされること
+   * 【テスト内容】SQLバリデーション失敗時に SqlValidationError がスローされること
+   * 【期待結果】SqlValidationError がスローされること（DB接続前にバリデーションで弾かれる）
    */
   it('should throw SqlValidationError when validation fails', async () => {
     vi.mocked(validate).mockReturnValue({ ok: false, reason: 'Forbidden keyword' })
 
-    await expect(executeQuery('DROP TABLE users')).rejects.toThrow(SqlValidationError)
+    await expect(executeQuery('validation-fail-conn-id', 'DROP TABLE users')).rejects.toThrow(SqlValidationError)
   })
 
   /**
@@ -249,8 +125,9 @@ describe('executeQuery', () => {
    * 【期待結果】正規化された QueryResult が返ること
    */
   it('should execute query and return normalized result for PostgreSQL', async () => {
-    process.env.DB_TYPE = 'postgresql'
-
+    const connId = 'pg-conn-id-001'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT id, name FROM users' })
 
     const mockRows = [
@@ -258,9 +135,12 @@ describe('executeQuery', () => {
       { id: 2, name: 'Bob' },
     ]
     const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT id, name FROM users', mockDb)
+    const result = await executeQuery(connId, 'SELECT id, name FROM users')
 
     expect(result.columns).toEqual(['id', 'name'])
     expect(result.rows).toHaveLength(2)
@@ -273,15 +153,19 @@ describe('executeQuery', () => {
    * 【期待結果】タプル形式の結果から正規化された QueryResult が返ること
    */
   it('should execute query and return normalized result for MySQL', async () => {
-    process.env.DB_TYPE = 'mysql'
-
+    const connId = 'mysql-conn-id-002'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'mysql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT id FROM orders' })
 
     const mockRows = [{ id: 1 }, { id: 2 }]
     const mockRaw = vi.fn().mockResolvedValue([mockRows, []])
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT id FROM orders', mockDb)
+    const result = await executeQuery(connId, 'SELECT id FROM orders')
 
     expect(result.columns).toEqual(['id'])
     expect(result.rows).toHaveLength(2)
@@ -293,14 +177,18 @@ describe('executeQuery', () => {
    * 【期待結果】columns が空配列、rows が空配列で返ること
    */
   it('should return empty columns and rows when result is empty', async () => {
-    process.env.DB_TYPE = 'postgresql'
-
+    const connId = 'pg-conn-id-003'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT * FROM empty_table' })
 
     const mockRaw = vi.fn().mockResolvedValue({ rows: [] })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT * FROM empty_table', mockDb)
+    const result = await executeQuery(connId, 'SELECT * FROM empty_table')
 
     expect(result.columns).toEqual([])
     expect(result.rows).toEqual([])
@@ -312,15 +200,19 @@ describe('executeQuery', () => {
    * 【期待結果】BigInt が文字列化されていること
    */
   it('should normalize BigInt values to strings', async () => {
-    process.env.DB_TYPE = 'postgresql'
-
+    const connId = 'pg-conn-id-004'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT big_num FROM data' })
 
     const mockRows = [{ big_num: BigInt('9999999999999999') }]
     const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT big_num FROM data', mockDb)
+    const result = await executeQuery(connId, 'SELECT big_num FROM data')
 
     expect(result.rows[0].big_num).toBe('9999999999999999')
   })
@@ -331,16 +223,20 @@ describe('executeQuery', () => {
    * 【期待結果】Date が ISO 8601 文字列化されていること
    */
   it('should normalize Date values to ISO strings', async () => {
-    process.env.DB_TYPE = 'postgresql'
-
+    const connId = 'pg-conn-id-005'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT created_at FROM data' })
 
     const testDate = new Date('2024-01-15T10:30:00.000Z')
     const mockRows = [{ created_at: testDate }]
     const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT created_at FROM data', mockDb)
+    const result = await executeQuery(connId, 'SELECT created_at FROM data')
 
     expect(result.rows[0].created_at).toBe('2024-01-15T10:30:00.000Z')
   })
@@ -351,54 +247,51 @@ describe('executeQuery', () => {
    * 【期待結果】null が保持されること
    */
   it('should preserve null values', async () => {
-    process.env.DB_TYPE = 'postgresql'
-
+    const connId = 'pg-conn-id-006'
+    const mockConnection = createMockConnection({ id: connId, dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
     vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT nullable_col FROM data' })
 
     const mockRows = [{ nullable_col: null }]
     const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    const result = await executeQuery('SELECT nullable_col FROM data', mockDb)
+    const result = await executeQuery(connId, 'SELECT nullable_col FROM data')
 
     expect(result.rows[0].nullable_col).toBeNull()
   })
+})
 
-  /**
-   * 【テスト対象】executeQuery
-   * 【テスト内容】sanitizedSql が使用されること
-   * 【期待結果】validate が返した sanitizedSql が DB に渡されること
-   */
-  it('should use sanitizedSql from validator', async () => {
-    process.env.DB_TYPE = 'postgresql'
+// ---------------------------------------------------------------------------
+// destroyConnection / destroyAllConnections のテスト
+// ---------------------------------------------------------------------------
 
-    vi.mocked(validate).mockReturnValue({ ok: true, sanitizedSql: 'SELECT * FROM users' })
-
-    const mockRaw = vi.fn().mockResolvedValue({ rows: [] })
-    const mockDb = { raw: mockRaw } as any
-
-    await executeQuery('SELECT * FROM users -- comment', mockDb)
-
-    // sanitizedSql が渡されていること（コメント除去後のSQL）
-    expect(mockRaw).toHaveBeenCalledWith('SELECT * FROM users')
+describe('destroyConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
   /**
-   * 【テスト対象】executeQuery
-   * 【テスト内容】sanitizedSql が undefined の場合は元の SQL が使用されること
-   * 【期待結果】元の SQL 文が DB に渡されること
+   * 【テスト対象】destroyConnection
+   * 【テスト内容】存在しない接続先IDを渡した場合
+   * 【期待結果】エラーなく完了すること（プールに存在しない場合は何もしない）
    */
-  it('should fall back to original sql when sanitizedSql is undefined', async () => {
-    process.env.DB_TYPE = 'postgresql'
+  it('should complete without error for non-existent connection id', async () => {
+    await expect(destroyConnection('non-existent-id')).resolves.not.toThrow()
+  })
+})
 
-    vi.mocked(validate).mockReturnValue({ ok: true })
-
-    const mockRaw = vi.fn().mockResolvedValue({ rows: [] })
-    const mockDb = { raw: mockRaw } as any
-
-    await executeQuery('SELECT 1', mockDb)
-
-    expect(mockRaw).toHaveBeenCalledWith('SELECT 1')
+describe('destroyAllConnections', () => {
+  /**
+   * 【テスト対象】destroyAllConnections
+   * 【テスト内容】プールが空の場合に呼び出した場合
+   * 【期待結果】エラーなく完了すること
+   */
+  it('should complete without error when pool is empty', async () => {
+    await expect(destroyAllConnections()).resolves.not.toThrow()
   })
 })
 

--- a/output_system/test/unit/frontend/useChat.test.ts
+++ b/output_system/test/unit/frontend/useChat.test.ts
@@ -100,9 +100,9 @@ describe('useChat', () => {
     ])
     const { result } = renderHook(() => useChat())
 
-    // Act: 質問を送信
+    // Act: 質問を送信（PBI #149: dbConnectionId が必須）
     await act(async () => {
-      await result.current.send('今月の売上を教えて')
+      await result.current.send('今月の売上を教えて', 'test-db-connection-id')
     })
 
     // Assert: ユーザーメッセージとアシスタントメッセージが追加されること
@@ -134,7 +134,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('test')
+      await result.current.send('test', 'test-db-connection-id')
     })
 
     // Assert: チャンクが結合されていること
@@ -160,7 +160,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('ユーザー一覧を教えて')
+      await result.current.send('ユーザー一覧を教えて', 'test-db-connection-id')
     })
 
     // Assert
@@ -189,7 +189,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('ユーザー一覧を教えて')
+      await result.current.send('ユーザー一覧を教えて', 'test-db-connection-id')
     })
 
     // Assert
@@ -216,7 +216,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('エラーを起こす質問')
+      await result.current.send('エラーを起こす質問', 'test-db-connection-id')
     })
 
     // Assert
@@ -241,7 +241,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('test')
+      await result.current.send('test', 'test-db-connection-id')
     })
 
     // Assert
@@ -285,7 +285,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('test')
+      await result.current.send('test', 'test-db-connection-id')
     })
 
     // Assert: conversationId が設定されること
@@ -307,7 +307,7 @@ describe('useChat', () => {
     ])
     const { result } = renderHook(() => useChat())
     await act(async () => {
-      await result.current.send('test')
+      await result.current.send('test', 'test-db-connection-id')
     })
     await waitFor(() => expect(result.current.messages).toHaveLength(2))
 
@@ -381,7 +381,7 @@ describe('useChat', () => {
 
     // Act
     await act(async () => {
-      await result.current.send('test')
+      await result.current.send('test', 'test-db-connection-id')
     })
 
     // Assert: エラーメッセージが設定されること

--- a/output_system/test/unit/schema.test.ts
+++ b/output_system/test/unit/schema.test.ts
@@ -2,29 +2,80 @@
  * 【モジュール】backend/src/services/schema.ts
  * スキーマ情報取得サービスのユニットテスト
  *
- * モックDBを使用して以下を検証する:
- * - PostgreSQL/MySQL 両DBで適切なSQLが実行されること
- * - buildSchemaInfo() が正しく INFORMATION_SCHEMA 行を変換すること
- * - fetchSchema() が DB_TYPE に応じて適切なロジックを呼び出すこと
- * - エラー時に例外が伝播すること
+ * PBI #149 改修後のテスト:
+ *   - fetchSchema(): dbConnectionId を引数に取り、connectionManager 経由で動的接続
+ *   - buildSchemaInfo(): 純粋関数のため直接テスト
+ *   - invalidateSchemaCache(): キャッシュ無効化の動作確認
+ *
+ * テスト方針:
+ *   - connectionManager.getById() をモックして実際のDB接続を行わない
+ *   - knex をモックして実際のSQLを実行しない
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// services/schema から必要なものをインポート
-// buildSchemaInfo は純粋関数のため直接テスト可能
+// connectionManager モジュールをモック（実DBへの接続を回避）
+vi.mock('../../backend/src/services/connectionManager', () => ({
+  getById: vi.fn(),
+  ConnectionNotFoundError: class ConnectionNotFoundError extends Error {
+    constructor(id: string) {
+      super(`DB connection with id '${id}' not found.`)
+      this.name = 'ConnectionNotFoundError'
+    }
+  },
+}))
+
+// knex モジュールをモック（実DB接続を回避）
+vi.mock('knex', () => {
+  return {
+    default: vi.fn(() => ({
+      raw: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })),
+  }
+})
+
 import {
   buildSchemaInfo,
   fetchSchema,
+  invalidateSchemaCache,
+  clearAllSchemaCache,
   type SchemaInfo,
 } from '../../backend/src/services/schema'
+import { getById } from '../../backend/src/services/connectionManager'
+import Knex from 'knex'
 
-// services/database モジュールをモック
-vi.mock('../../backend/src/services/database', () => ({
-  getDb: vi.fn(),
-}))
+// ---------------------------------------------------------------------------
+// テストヘルパー
+// ---------------------------------------------------------------------------
 
-import { getDb } from '../../backend/src/services/database'
+/**
+ * DB接続先モックオブジェクトを生成するヘルパー
+ */
+function createMockConnection(overrides: Partial<{
+  id: string
+  dbType: 'mysql' | 'postgresql'
+  host: string
+  port: number
+  username: string
+  password: string
+  databaseName: string
+}> = {}) {
+  return {
+    id: 'test-connection-id',
+    name: 'テストDB',
+    dbType: 'postgresql' as const,
+    host: 'localhost',
+    port: 5432,
+    username: 'testuser',
+    password: 'testpass',
+    databaseName: 'testdb',
+    isLastUsed: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
 
 // -------------------------------------------------------------------
 // buildSchemaInfo のユニットテスト
@@ -134,30 +185,23 @@ describe('buildSchemaInfo', () => {
 
 /**
  * 【モジュール】fetchSchema
- * DB_TYPE に応じてPostgreSQL/MySQLのSQL実行と結果変換を行う関数のテスト
+ * dbConnectionId を受け取り、connectionManager 経由で動的接続してスキーマを取得する関数のテスト
  */
 describe('fetchSchema', () => {
-  const originalEnv = process.env
-
   beforeEach(() => {
-    // 環境変数のリセット
-    process.env = { ...originalEnv }
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    process.env = originalEnv
+    // 各テスト前にキャッシュをクリアしてテストを独立させる
+    clearAllSchemaCache()
   })
 
   /**
    * 【テスト対象】fetchSchema（PostgreSQL向け）
-   * 【テスト内容】DB_TYPE=postgresql のとき、current_schema() を使うクエリが実行されること
+   * 【テスト内容】dbType=postgresql のとき、current_schema() を使うクエリが実行されること
    * 【期待結果】INFORMATION_SCHEMA からテーブル・カラム情報が取得され、SchemaInfo形式で返ること
    */
   it('should fetch schema using current_schema() for PostgreSQL', async () => {
-    // Arrange
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_NAME = 'pgdb'
+    const mockConnection = createMockConnection({ dbType: 'postgresql', databaseName: 'pgdb' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
 
     const mockRows = [
       { table_name: 'products', table_comment: null, column_name: 'id', data_type: 'integer', is_nullable: 'NO', column_comment: null },
@@ -165,14 +209,13 @@ describe('fetchSchema', () => {
     ]
 
     const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    vi.mocked(getDb).mockReturnValue(mockDb)
+    const result: SchemaInfo = await fetchSchema('test-connection-id')
 
-    // Act
-    const result: SchemaInfo = await fetchSchema()
-
-    // Assert
     expect(result.database).toBe('pgdb')
     expect(result.tables).toHaveLength(1)
     expect(result.tables[0].name).toBe('products')
@@ -187,13 +230,12 @@ describe('fetchSchema', () => {
 
   /**
    * 【テスト対象】fetchSchema（MySQL向け）
-   * 【テスト内容】DB_TYPE=mysql のとき、DATABASE() を使うクエリが実行されること
+   * 【テスト内容】dbType=mysql のとき、DATABASE() を使うクエリが実行されること
    * 【期待結果】INFORMATION_SCHEMA からテーブル・カラム情報が取得され、SchemaInfo形式で返ること
    */
   it('should fetch schema using DATABASE() for MySQL', async () => {
-    // Arrange
-    process.env.DB_TYPE = 'mysql'
-    process.env.DB_NAME = 'mysqldb'
+    const mockConnection = createMockConnection({ dbType: 'mysql', databaseName: 'mysqldb' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
 
     const mockRows = [
       { table_name: 'customers', table_comment: null, column_name: 'customer_id', data_type: 'int', is_nullable: 'NO', column_comment: null },
@@ -202,14 +244,13 @@ describe('fetchSchema', () => {
 
     // MySQL の knex.raw は [rows, fields] のタプルを返す
     const mockRaw = vi.fn().mockResolvedValue([mockRows, []])
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    vi.mocked(getDb).mockReturnValue(mockDb)
+    const result: SchemaInfo = await fetchSchema('test-connection-id')
 
-    // Act
-    const result: SchemaInfo = await fetchSchema()
-
-    // Assert
     expect(result.database).toBe('mysqldb')
     expect(result.tables).toHaveLength(1)
     expect(result.tables[0].name).toBe('customers')
@@ -225,60 +266,22 @@ describe('fetchSchema', () => {
 
   /**
    * 【テスト対象】fetchSchema
-   * 【テスト内容】DB_TYPE が不正な値の場合
+   * 【テスト内容】dbType が不正な値の場合
    * 【期待結果】サポート外エラーがスローされること
    */
-  it('should throw error when DB_TYPE is unsupported', async () => {
-    // Arrange
-    process.env.DB_TYPE = 'oracle'
-    process.env.DB_NAME = 'oracledb'
+  it('should throw error when dbType is unsupported', async () => {
+    const mockConnection = createMockConnection({ dbType: 'postgresql' })
+    // dbType を上書きするために any キャスト
+    const connWithInvalidType = { ...mockConnection, dbType: 'oracle' }
+    vi.mocked(getById).mockReturnValue(connWithInvalidType as any)
 
-    const mockDb = { raw: vi.fn() } as any
-    vi.mocked(getDb).mockReturnValue(mockDb)
+    const mockRaw = vi.fn()
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    // Act & Assert
-    await expect(fetchSchema()).rejects.toThrow('oracle')
-  })
-
-  /**
-   * 【テスト対象】fetchSchema
-   * 【テスト内容】DB_TYPE が未設定の場合
-   * 【期待結果】サポート外エラーがスローされること
-   */
-  it('should throw error when DB_TYPE is not set', async () => {
-    // Arrange
-    delete process.env.DB_TYPE
-    process.env.DB_NAME = 'somedb'
-
-    const mockDb = { raw: vi.fn() } as any
-    vi.mocked(getDb).mockReturnValue(mockDb)
-
-    // Act & Assert
-    await expect(fetchSchema()).rejects.toThrow()
-  })
-
-  /**
-   * 【テスト対象】fetchSchema
-   * 【テスト内容】引数でknexインスタンスを渡した場合
-   * 【期待結果】getDb() を呼ばずに、渡されたインスタンスを使用すること
-   */
-  it('should use provided db instance instead of getDb()', async () => {
-    // Arrange
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_NAME = 'injecteddb'
-
-    const mockRows = [
-      { table_name: 'test_table', table_comment: null, column_name: 'col1', data_type: 'integer', is_nullable: 'NO', column_comment: null },
-    ]
-    const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
-    const injectedDb = { raw: mockRaw } as any
-
-    // Act
-    const result = await fetchSchema(injectedDb)
-
-    // Assert
-    expect(result.database).toBe('injecteddb')
-    expect(getDb).not.toHaveBeenCalled()
+    await expect(fetchSchema('test-connection-id')).rejects.toThrow('oracle')
   })
 
   /**
@@ -287,16 +290,69 @@ describe('fetchSchema', () => {
    * 【期待結果】エラーが呼び出し元に伝播されること
    */
   it('should propagate DB errors to the caller', async () => {
-    // Arrange
-    process.env.DB_TYPE = 'postgresql'
-    process.env.DB_NAME = 'errordb'
+    const mockConnection = createMockConnection({ dbType: 'postgresql' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
 
     const mockRaw = vi.fn().mockRejectedValue(new Error('Connection refused'))
-    const mockDb = { raw: mockRaw } as any
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
 
-    vi.mocked(getDb).mockReturnValue(mockDb)
+    await expect(fetchSchema('test-connection-id')).rejects.toThrow('Connection refused')
+  })
+})
 
-    // Act & Assert
-    await expect(fetchSchema()).rejects.toThrow('Connection refused')
+// -------------------------------------------------------------------
+// invalidateSchemaCache のユニットテスト
+// -------------------------------------------------------------------
+
+/**
+ * 【モジュール】invalidateSchemaCache
+ * スキーマキャッシュ無効化関数のテスト
+ */
+describe('invalidateSchemaCache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAllSchemaCache()
+  })
+
+  /**
+   * 【テスト対象】invalidateSchemaCache
+   * 【テスト内容】存在しないキーを無効化しようとした場合
+   * 【期待結果】エラーなく完了すること（べき等）
+   */
+  it('should complete without error for non-existent cache key', () => {
+    expect(() => invalidateSchemaCache('non-existent-id')).not.toThrow()
+  })
+
+  /**
+   * 【テスト対象】invalidateSchemaCache
+   * 【テスト内容】キャッシュ無効化後にfetchSchemaを呼んだ場合
+   * 【期待結果】キャッシュではなくDBから再取得されること（getById が再度呼ばれること）
+   */
+  it('should cause re-fetch after cache invalidation', async () => {
+    const mockConnection = createMockConnection({ dbType: 'postgresql', databaseName: 'pgdb' })
+    vi.mocked(getById).mockReturnValue(mockConnection)
+
+    const mockRows = [
+      { table_name: 'test', table_comment: null, column_name: 'id', data_type: 'integer', is_nullable: 'NO', column_comment: null },
+    ]
+    const mockRaw = vi.fn().mockResolvedValue({ rows: mockRows })
+    vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      raw: mockRaw,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
+
+    // 1回目のfetchSchema（キャッシュされる）
+    await fetchSchema('test-connection-id')
+    expect(mockRaw).toHaveBeenCalledTimes(1)
+
+    // キャッシュ無効化
+    invalidateSchemaCache('test-connection-id')
+
+    // 2回目のfetchSchema（キャッシュが無効化されているのでDBから再取得）
+    await fetchSchema('test-connection-id')
+    expect(mockRaw).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary

- `schema.ts`: `dbConnectionId` パラメータを追加し、`connectionManager.getById()` 経由で動的DB接続。メモリキャッシュ (`Map<dbConnectionId, SchemaInfo>`) を追加し、接続先更新・削除時のキャッシュ無効化メソッド `invalidateSchemaCache()` を公開
- `database.ts`: 固定 `.env` 接続を廃止し、接続プール (`Map<dbConnectionId, KnexType>`) で動的管理。`executeQuery(dbConnectionId, sql)` に変更、`destroyConnection`/`destroyAllConnections` を追加
- `routes/schema.ts`: `dbConnectionId` クエリパラメータ必須 (UUID v4 バリデーション) に変更
- `routes/chat.ts`: リクエストボディから `dbConnectionId` を受け取り `fetchSchema`/`executeQuery` に渡す
- `routes/connections.ts`: PUT/DELETE 時にスキーマキャッシュと接続プールを破棄
- フロントエンド: ヘッダーにDB接続先選択ドロップダウン追加、未選択時にチャット入力を無効化

## Test plan

- [x] 全ユニットテスト (216件) パス確認
- [x] Docker イメージビルド成功確認
- [x] アプリケーション起動・ヘルスチェック確認
- [x] UI 動作確認 (スクリーンショット取得)

🤖 Generated with [Claude Code](https://claude.com/claude-code)