### PR TITLE
feat(graphql): GraphQL接続先の登録・管理機能 (PBI #200)

### DIFF
--- a/output_system/backend/src/routes/connections.ts
+++ b/output_system/backend/src/routes/connections.ts
@@ -43,9 +43,10 @@ const router = Router()
 
 /**
  * 許可する dbType 一覧
- * api.md の定義に準拠。mysql と postgresql のみサポート。
+ * api.md の定義に準拠。mysql / postgresql / graphql をサポート。
+ * PBI #200: 'graphql' を追加
  */
-const VALID_DB_TYPES = ['mysql', 'postgresql'] as const
+const VALID_DB_TYPES = ['mysql', 'postgresql', 'graphql'] as const
 
 /**
  * リクエストボディのバリデーション結果型
@@ -58,22 +59,29 @@ interface ValidationResult {
 }
 
 /**
- * DB接続先のリクエストボディをバリデーションする
+ * DB/GraphQL接続先のリクエストボディをバリデーションする
  *
- * 必須フィールド: name, dbType, host, port, username, databaseName
- * パスワード: POST（必須）/ PUT（省略可）
+ * DB接続（mysql / postgresql）の必須フィールド: name, dbType, host, port, username, databaseName
+ * GraphQL接続の必須フィールド: name, dbType, endpointUrl
  *
  * バリデーションルール:
+ *   共通:
  *   - name: 必須、文字列
- *   - dbType: 必須、'mysql' または 'postgresql'
+ *   - dbType: 必須、'mysql' | 'postgresql' | 'graphql'
+ *
+ *   DB接続時（mysql/postgresql）:
  *   - host: 必須、文字列
  *   - port: 必須、1〜65535 の整数
  *   - username: 必須、文字列
  *   - databaseName: 必須、文字列
  *   - password: POST 時は必須、PUT 時は省略可（省略時は既存パスワードを維持）
  *
+ *   GraphQL接続時:
+ *   - endpointUrl: 必須、HTTP/HTTPSスキーマのURL形式
+ *   - host/port/username/password/databaseName: 不要（あっても無視）
+ *
  * @param body - リクエストボディ（型不明のため unknown）
- * @param requirePassword - パスワードを必須とするか（POST: true, PUT: false）
+ * @param requirePassword - パスワードを必須とするか（DB接続のPOST時: true, PUT時: false）
  * @returns バリデーション結果（input または error を含む）
  */
 function validateConnectionInput(body: unknown, requirePassword: boolean): ValidationResult {
@@ -83,22 +91,63 @@ function validateConnectionInput(body: unknown, requirePassword: boolean): Valid
 
   const b = body as Record<string, unknown>
 
-  // 必須フィールドのチェック
-  const requiredFields = ['name', 'dbType', 'host', 'port', 'username', 'databaseName']
-  for (const field of requiredFields) {
+  // name は常に必須
+  if (!b.name || b.name === '') {
+    return { error: "Field 'name' is required." }
+  }
+  if (typeof b.name !== 'string') {
+    return { error: "Field 'name' must be a string." }
+  }
+
+  // dbType の必須チェックと値チェック
+  if (!b.dbType || b.dbType === '') {
+    return { error: "Field 'dbType' is required." }
+  }
+  if (!VALID_DB_TYPES.includes(b.dbType as typeof VALID_DB_TYPES[number])) {
+    return { error: `Field 'dbType' must be one of: ${VALID_DB_TYPES.join(', ')}.` }
+  }
+
+  const dbType = b.dbType as typeof VALID_DB_TYPES[number]
+
+  // GraphQL接続時のバリデーション
+  if (dbType === 'graphql') {
+    // endpointUrl が必須
+    if (!b.endpointUrl || b.endpointUrl === '') {
+      return { error: "Field 'endpointUrl' is required for GraphQL connections." }
+    }
+    if (typeof b.endpointUrl !== 'string') {
+      return { error: "Field 'endpointUrl' must be a string." }
+    }
+    // URL形式チェック（HTTPまたはHTTPSスキーマのみ許可）
+    try {
+      const url = new URL(b.endpointUrl)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return { error: "Field 'endpointUrl' must start with http:// or https://." }
+      }
+    } catch {
+      return { error: "Field 'endpointUrl' must be a valid URL." }
+    }
+
+    return {
+      input: {
+        name: b.name,
+        dbType: 'graphql',
+        endpointUrl: b.endpointUrl,
+      },
+    }
+  }
+
+  // DB接続時（mysql / postgresql）のバリデーション: 従来通り
+  const requiredDbFields = ['host', 'port', 'username', 'databaseName']
+  for (const field of requiredDbFields) {
     if (b[field] === undefined || b[field] === null || b[field] === '') {
       return { error: `Field '${field}' is required.` }
     }
   }
 
-  // パスワードの必須チェック（POST 時のみ）
+  // パスワードの必須チェック（DB接続のPOST 時のみ）
   if (requirePassword && (b.password === undefined || b.password === null || b.password === '')) {
     return { error: "Field 'password' is required." }
-  }
-
-  // dbType の値チェック（mysql / postgresql のみ許可）
-  if (!VALID_DB_TYPES.includes(b.dbType as typeof VALID_DB_TYPES[number])) {
-    return { error: `Field 'dbType' must be one of: ${VALID_DB_TYPES.join(', ')}.` }
   }
 
   // port の型・範囲チェック（1〜65535 の整数）
@@ -108,7 +157,7 @@ function validateConnectionInput(body: unknown, requirePassword: boolean): Valid
   }
 
   // 文字列フィールドの型チェック
-  const stringFields = ['name', 'host', 'username', 'databaseName']
+  const stringFields = ['host', 'username', 'databaseName']
   for (const field of stringFields) {
     if (typeof b[field] !== 'string') {
       return { error: `Field '${field}' must be a string.` }
@@ -117,8 +166,8 @@ function validateConnectionInput(body: unknown, requirePassword: boolean): Valid
 
   return {
     input: {
-      name: b.name as string,
-      dbType: b.dbType as 'mysql' | 'postgresql',
+      name: b.name,
+      dbType: dbType as 'mysql' | 'postgresql' | 'graphql',
       host: b.host as string,
       port,
       username: b.username as string,
@@ -197,8 +246,12 @@ router.post('/', async (req: Request, res: Response) => {
  * POST /api/connections/test
  * 接続テストを実行する
  *
- * 指定された接続情報で実際に DB に接続し、成功/失敗を返す。
+ * 指定された接続情報で実際に DB/GraphQL エンドポイントに接続し、成功/失敗を返す。
  * タイムアウトは 5 秒以内（connectionManager.ts 内で設定）。
+ *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql': Introspection Query で接続テスト（パスワード不要）
+ * - dbType='mysql'/'postgresql': 従来の SELECT 1 で接続テスト
  *
  * 注意: このルートは /api/connections/:id より先に定義する必要がある。
  * Express のルートマッチングは定義順に行われるため、'test' が :id として
@@ -208,8 +261,11 @@ router.post('/', async (req: Request, res: Response) => {
  * @returns 400 Bad Request - 接続失敗またはバリデーションエラー
  */
 router.post('/test', async (req: Request, res: Response) => {
-  // リクエストボディをバリデーション（パスワード必須）
-  const validation = validateConnectionInput(req.body, true)
+  // GraphQL接続テストの場合はパスワード不要（requirePassword=false）
+  // DB接続テストの場合はパスワード必須（requirePassword=true）
+  const body = req.body as Record<string, unknown>
+  const isGraphQL = body.dbType === 'graphql'
+  const validation = validateConnectionInput(req.body, !isGraphQL)
   if (validation.error) {
     return res.status(400).json({ error: validation.error })
   }

--- a/output_system/backend/src/services/connectionManager.ts
+++ b/output_system/backend/src/services/connectionManager.ts
@@ -76,22 +76,30 @@ export class ConnectionNotFoundError extends Error {
  *
  * パスワードは平文で受け取り、サービス内で暗号化して保存する。
  * APIリクエストボディの型に対応する。
+ *
+ * PBI #200: GraphQL対応
+ * - dbType に 'graphql' を追加
+ * - endpointUrl フィールドを追加（GraphQL時は必須、DB時は不要）
+ * - GraphQL時: host/port/username/password/databaseName は省略可
+ * - DB時: 従来通り host/port/username/databaseName が必須、password は POST で必須
  */
 export interface DbConnectionInput {
   /** 接続名（表示用・UNIQUE制約あり） */
   name: string
-  /** DBタイプ（mysql / postgresql） */
-  dbType: 'mysql' | 'postgresql'
-  /** DBホスト名またはIPアドレス */
-  host: string
-  /** DBポート番号 */
-  port: number
-  /** DBユーザー名 */
-  username: string
-  /** DBパスワード（平文）。更新時はオプション（省略時は既存パスワードを維持） */
+  /** DBタイプ（mysql / postgresql / graphql） */
+  dbType: 'mysql' | 'postgresql' | 'graphql'
+  /** DBホスト名またはIPアドレス（DB時必須、GraphQL時不要） */
+  host?: string
+  /** DBポート番号（DB時必須、GraphQL時不要） */
+  port?: number
+  /** DBユーザー名（DB時必須、GraphQL時不要） */
+  username?: string
+  /** DBパスワード（平文）。更新時はオプション（省略時は既存パスワードを維持）。GraphQL時は不要 */
   password?: string
-  /** データベース名 */
-  databaseName: string
+  /** データベース名（DB時必須、GraphQL時不要） */
+  databaseName?: string
+  /** GraphQLエンドポイントURL（GraphQL時必須、DB時不要） */
+  endpointUrl?: string
 }
 
 /**
@@ -99,22 +107,29 @@ export interface DbConnectionInput {
  *
  * パスワードを含まない安全なレスポンス型。
  * GET /api/connections の一覧取得で使用する。
+ *
+ * PBI #200: GraphQL対応
+ * - dbType に 'graphql' を追加
+ * - endpointUrl フィールドを追加
+ * - GraphQL時: host/port/username/databaseName は null になる
  */
 export interface DbConnectionPublic {
   /** 接続先の一意識別子（UUID） */
   id: string
   /** 接続名 */
   name: string
-  /** DBタイプ */
-  dbType: 'mysql' | 'postgresql'
-  /** DBホスト名 */
-  host: string
-  /** DBポート番号 */
-  port: number
-  /** DBユーザー名 */
-  username: string
-  /** データベース名 */
-  databaseName: string
+  /** DBタイプ（mysql / postgresql / graphql） */
+  dbType: 'mysql' | 'postgresql' | 'graphql'
+  /** DBホスト名（GraphQL時はnull） */
+  host: string | null
+  /** DBポート番号（GraphQL時はnull） */
+  port: number | null
+  /** DBユーザー名（GraphQL時はnull） */
+  username: string | null
+  /** データベース名（GraphQL時はnull） */
+  databaseName: string | null
+  /** GraphQLエンドポイントURL（DB時はnull） */
+  endpointUrl: string | null
   /** 最後に使用したDB フラグ */
   isLastUsed: boolean
   /** 作成日時（ISO 8601形式） */
@@ -143,6 +158,10 @@ export interface ConnectionTestResult {
  * SQLite から取得した生データを API レスポンス用の型に変換する。
  * password_encrypted フィールドは除外する。
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: endpointUrl を含め、host/port/username/databaseName はnullを返す
+ * - dbType='mysql'/'postgresql' の場合: 従来通り。endpointUrl はnull
+ *
  * @param row - SQLite から取得した DbConnectionRow
  * @returns パスワードを除いた DbConnectionPublic
  */
@@ -150,11 +169,14 @@ function rowToPublic(row: DbConnectionRow): DbConnectionPublic {
   return {
     id: row.id,
     name: row.name,
-    dbType: row.db_type as 'mysql' | 'postgresql',
-    host: row.host,
-    port: row.port,
-    username: row.username,
-    databaseName: row.database_name,
+    dbType: row.db_type as 'mysql' | 'postgresql' | 'graphql',
+    // GraphQL時はnull（DB時は値が入る）
+    host: row.host ?? null,
+    port: row.port ?? null,
+    username: row.username ?? null,
+    databaseName: row.database_name ?? null,
+    // GraphQL時はエンドポイントURL（DB時はnull）
+    endpointUrl: row.endpoint_url ?? null,
     // SQLite では BOOLEAN を INTEGER（0/1）で保存しているため変換
     isLastUsed: row.is_last_used === 1,
     createdAt: row.created_at,
@@ -172,12 +194,17 @@ function rowToPublic(row: DbConnectionRow): DbConnectionPublic {
  * パスワードを AES-256-GCM で暗号化してから SQLite に保存する。
  * 接続名が重複する場合は DuplicateConnectionNameError をスローする。
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: endpointUrl を保存、host/port/username/password/databaseName はNULL
+ * - dbType='mysql'/'postgresql' の場合: 従来通り
+ *
  * @param input - 接続先情報（パスワードは平文で受け取る）
  * @returns 登録された接続先情報（パスワードなし）
  * @throws DuplicateConnectionNameError 接続名が重複する場合
  *
  * @example
  * ```typescript
+ * // DB接続先の登録
  * const connection = await create({
  *   name: '本番DB',
  *   dbType: 'postgresql',
@@ -187,27 +214,50 @@ function rowToPublic(row: DbConnectionRow): DbConnectionPublic {
  *   password: 'mypassword',
  *   databaseName: 'production',
  * })
+ *
+ * // GraphQL接続先の登録
+ * const graphqlConnection = await create({
+ *   name: 'My GraphQL API',
+ *   dbType: 'graphql',
+ *   endpointUrl: 'https://api.example.com/graphql',
+ * })
  * ```
  */
 export function create(input: DbConnectionInput): DbConnectionPublic {
   const db = getHistoryDb()
   const id = uuidv4()
 
-  // パスワードを暗号化（平文パスワードは保存しない）
-  const passwordEncrypted = encrypt(input.password ?? '')
-
   try {
-    const row = createDbConnection(db, {
-      id,
-      name: input.name,
-      db_type: input.dbType,
-      host: input.host,
-      port: input.port,
-      username: input.username,
-      password_encrypted: passwordEncrypted,
-      database_name: input.databaseName,
-    })
-    return rowToPublic(row)
+    if (input.dbType === 'graphql') {
+      // GraphQL接続先: endpointUrl のみ保存。host/port/username/password/databaseName はNULL
+      const row = createDbConnection(db, {
+        id,
+        name: input.name,
+        db_type: input.dbType,
+        host: null,
+        port: null,
+        username: null,
+        password_encrypted: null,
+        database_name: null,
+        endpoint_url: input.endpointUrl,
+      })
+      return rowToPublic(row)
+    } else {
+      // DB接続先（MySQL/PostgreSQL）: 従来通り、パスワードを暗号化して保存
+      const passwordEncrypted = encrypt(input.password ?? '')
+      const row = createDbConnection(db, {
+        id,
+        name: input.name,
+        db_type: input.dbType,
+        host: input.host,
+        port: input.port,
+        username: input.username,
+        password_encrypted: passwordEncrypted,
+        database_name: input.databaseName,
+        endpoint_url: null,
+      })
+      return rowToPublic(row)
+    }
   } catch (err) {
     // SQLite の UNIQUE 制約違反エラーを DuplicateConnectionNameError に変換する
     // better-sqlite3 では UNIQUE 制約違反は "UNIQUE constraint failed" メッセージで通知される
@@ -244,6 +294,10 @@ export function getAll(): DbConnectionPublic[] {
  * 内部利用のみ（チャットAPI等で実際にDB接続する場合）。
  * APIレスポンスにはこの関数の戻り値を直接返さないこと。
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: password は空文字（暗号化不要）、endpointUrl を含む
+ * - dbType='mysql'/'postgresql' の場合: 従来通り
+ *
  * @param id - 取得する接続先ID
  * @returns 接続先情報（復号済みパスワード含む）
  * @throws ConnectionNotFoundError 指定IDの接続先が存在しない場合
@@ -252,7 +306,12 @@ export function getAll(): DbConnectionPublic[] {
  * ```typescript
  * // チャットAPI内での使用例
  * const conn = getById(dbConnectionId)
- * const knexInstance = buildKnexInstance(conn.dbType, conn.host, conn.port, conn.username, conn.password, conn.databaseName)
+ * if (conn.dbType === 'graphql') {
+ *   // GraphQL APIへのIntrospection等
+ *   const endpoint = conn.endpointUrl
+ * } else {
+ *   const knexInstance = buildKnexInstance(conn.dbType, conn.host!, conn.port!, ...)
+ * }
  * ```
  */
 export function getById(id: string): DbConnectionPublic & { password: string } {
@@ -263,8 +322,8 @@ export function getById(id: string): DbConnectionPublic & { password: string } {
     throw new ConnectionNotFoundError(id)
   }
 
-  // パスワードを復号して返す（内部利用のみ）
-  const password = decrypt(row.password_encrypted)
+  // GraphQL接続先の場合はパスワード復号をスキップ（password_encryptedはNULL）
+  const password = row.password_encrypted ? decrypt(row.password_encrypted) : ''
 
   return {
     ...rowToPublic(row),
@@ -278,6 +337,10 @@ export function getById(id: string): DbConnectionPublic & { password: string } {
  * 指定されたフィールドのみ更新する（パスワードは指定時のみ再暗号化）。
  * 接続名が重複する場合は DuplicateConnectionNameError をスローする。
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: endpointUrl を更新、host/port/username/password/databaseName はNULL
+ * - dbType='mysql'/'postgresql' の場合: 従来通り。endpointUrl はNULL
+ *
  * @param id - 更新する接続先ID
  * @param input - 更新情報（パスワードは省略可。省略時は既存パスワードを維持）
  * @returns 更新後の接続先情報（パスワードなし）
@@ -286,11 +349,14 @@ export function getById(id: string): DbConnectionPublic & { password: string } {
  *
  * @example
  * ```typescript
- * // パスワード変更なし
- * const updated = update('uuid-xxx', { name: '新名前', host: 'new.host.com', ... })
+ * // DB接続先のパスワード変更なし更新
+ * const updated = update('uuid-xxx', { name: '新名前', dbType: 'mysql', host: 'new.host.com', ... })
  *
- * // パスワード変更あり
+ * // DB接続先のパスワード変更あり更新
  * const updated = update('uuid-xxx', { ..., password: 'newpassword' })
+ *
+ * // GraphQL接続先の更新
+ * const updated = update('uuid-xxx', { name: 'New API', dbType: 'graphql', endpointUrl: 'https://new.api.com/graphql' })
  * ```
  */
 export function update(id: string, input: DbConnectionInput): DbConnectionPublic {
@@ -302,40 +368,66 @@ export function update(id: string, input: DbConnectionInput): DbConnectionPublic
     throw new ConnectionNotFoundError(id)
   }
 
-  // パスワードの処理:
-  // - input.password が指定されている場合は再暗号化
-  // - 省略されている場合は既存の暗号化済みパスワードをそのまま使用
-  const passwordEncrypted =
-    input.password !== undefined
-      ? encrypt(input.password)
-      : existing.password_encrypted
-
   const now = new Date().toISOString()
 
   try {
-    const stmt = db.prepare(`
-      UPDATE db_connections
-      SET name = @name,
-          db_type = @db_type,
-          host = @host,
-          port = @port,
-          username = @username,
-          password_encrypted = @password_encrypted,
-          database_name = @database_name,
-          updated_at = @updated_at
-      WHERE id = @id
-    `)
-    stmt.run({
-      id,
-      name: input.name,
-      db_type: input.dbType,
-      host: input.host,
-      port: input.port,
-      username: input.username,
-      password_encrypted: passwordEncrypted,
-      database_name: input.databaseName,
-      updated_at: now,
-    })
+    if (input.dbType === 'graphql') {
+      // GraphQL接続先の更新: endpointUrl のみ更新、host/port/username/password/databaseName はNULL
+      const stmt = db.prepare(`
+        UPDATE db_connections
+        SET name = @name,
+            db_type = @db_type,
+            host = NULL,
+            port = NULL,
+            username = NULL,
+            password_encrypted = NULL,
+            database_name = NULL,
+            endpoint_url = @endpoint_url,
+            updated_at = @updated_at
+        WHERE id = @id
+      `)
+      stmt.run({
+        id,
+        name: input.name,
+        db_type: input.dbType,
+        endpoint_url: input.endpointUrl ?? null,
+        updated_at: now,
+      })
+    } else {
+      // DB接続先（MySQL/PostgreSQL）の更新: 従来通り
+      // パスワードの処理:
+      // - input.password が指定されている場合は再暗号化
+      // - 省略されている場合は既存の暗号化済みパスワードをそのまま使用
+      const passwordEncrypted =
+        input.password !== undefined
+          ? encrypt(input.password)
+          : existing.password_encrypted
+
+      const stmt = db.prepare(`
+        UPDATE db_connections
+        SET name = @name,
+            db_type = @db_type,
+            host = @host,
+            port = @port,
+            username = @username,
+            password_encrypted = @password_encrypted,
+            database_name = @database_name,
+            endpoint_url = NULL,
+            updated_at = @updated_at
+        WHERE id = @id
+      `)
+      stmt.run({
+        id,
+        name: input.name,
+        db_type: input.dbType,
+        host: input.host ?? null,
+        port: input.port ?? null,
+        username: input.username ?? null,
+        password_encrypted: passwordEncrypted,
+        database_name: input.databaseName ?? null,
+        updated_at: now,
+      })
+    }
   } catch (err) {
     // SQLite の UNIQUE 制約違反エラーを DuplicateConnectionNameError に変換する
     if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
@@ -407,19 +499,20 @@ export function setLastUsed(id: string): void {
 // =============================================================================
 
 /**
- * 指定した接続情報でDB接続テストを行う
+ * 指定した接続情報でDB/GraphQL接続テストを行う
  *
- * knex.js を使って MySQL / PostgreSQL に実際に接続し、
- * 簡単なクエリ（SELECT 1）を実行して接続可否を確認する。
+ * DB接続（MySQL/PostgreSQL）: knex.js を使って実際に接続し、SELECT 1 を実行して接続可否を確認する。
+ * GraphQL接続: Introspection Query（{ __schema { types { name } } }）を実行して接続可否を確認する。
  *
  * タイムアウト: 5秒（接続待ちが長引かないよう制限）
- * knex インスタンスはテスト後に即 destroy する（リソースリーク防止）。
+ * DB接続テスト用の knex インスタンスはテスト後に即 destroy する（リソースリーク防止）。
  *
  * @param input - 接続先情報（パスワードは平文で受け取る）
  * @returns 接続テスト結果（成功フラグとメッセージ）
  *
  * @example
  * ```typescript
+ * // DB接続テスト
  * const result = await testConnection({
  *   name: 'テスト接続',
  *   dbType: 'postgresql',
@@ -430,10 +523,23 @@ export function setLastUsed(id: string): void {
  *   databaseName: 'mydb',
  * })
  * // => { success: true, message: 'Connection successful.' }
- * // => { success: false, message: 'Connection failed: ...' }
+ *
+ * // GraphQL接続テスト
+ * const result = await testConnection({
+ *   name: 'My GraphQL API',
+ *   dbType: 'graphql',
+ *   endpointUrl: 'https://api.example.com/graphql',
+ * })
+ * // => { success: true, message: 'GraphQL Introspection successful.' }
  * ```
  */
 export async function testConnection(input: DbConnectionInput): Promise<ConnectionTestResult> {
+  // GraphQL接続テスト: Introspection Query を実行
+  if (input.dbType === 'graphql') {
+    return testGraphQLConnection(input.endpointUrl ?? '')
+  }
+
+  // DB接続テスト（MySQL/PostgreSQL）: knex.js で SELECT 1 を実行
   // knex クライアント識別子のマッピング
   // mysql → mysql2（knex v3では mysql2 を推奨）
   // postgresql → pg
@@ -493,5 +599,109 @@ export async function testConnection(input: DbConnectionInput): Promise<Connecti
     // テスト後は必ず knex インスタンスを破棄してリソースをリリースする
     // destroy() を呼ばないと DB 接続プールが残り続けてリソースリークが発生する
     await testKnex.destroy()
+  }
+}
+
+/**
+ * GraphQL Introspection Query を実行して接続テストを行う
+ *
+ * Introspection Query（{ __schema { types { name } } }）を指定エンドポイントにPOSTし、
+ * 正常なレスポンスが返ることを確認する。
+ *
+ * タイムアウト: 5秒（AbortSignal.timeout を使用）
+ *
+ * Introspection が無効になっているGraphQL APIへの対応:
+ * - レスポンスに "errors" が含まれ、IntrospectionNotAllowed等のエラーが来る場合は
+ *   「Introspectionが無効」として案内メッセージを返す
+ *
+ * @param endpointUrl - GraphQLエンドポイントURL
+ * @returns 接続テスト結果（成功フラグとメッセージ）
+ */
+async function testGraphQLConnection(endpointUrl: string): Promise<ConnectionTestResult> {
+  if (!endpointUrl) {
+    return {
+      success: false,
+      message: 'エンドポイントURLが指定されていません。',
+    }
+  }
+
+  // 最小限のIntrospection Query（型名リストのみ取得）
+  const introspectionQuery = `{ __schema { types { name } } }`
+
+  try {
+    // Node.js標準のfetchでGraphQLエンドポイントにPOSTリクエストを送信
+    // AbortSignal.timeout でタイムアウト5秒を設定
+    const response = await fetch(endpointUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ query: introspectionQuery }),
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!response.ok) {
+      return {
+        success: false,
+        message: `GraphQL接続に失敗しました: HTTP ${response.status} ${response.statusText}`,
+      }
+    }
+
+    // レスポンスJSONをパース
+    const data = await response.json() as { data?: { __schema?: unknown }; errors?: Array<{ message: string }> }
+
+    // errorsフィールドにIntrospection無効のエラーが含まれる場合は専用メッセージを返す
+    if (data.errors && data.errors.length > 0) {
+      const errorMessages = data.errors.map((e) => e.message).join('; ')
+      const isIntrospectionDisabled = data.errors.some(
+        (e) =>
+          e.message.toLowerCase().includes('introspection') ||
+          e.message.toLowerCase().includes('not allowed') ||
+          e.message.toLowerCase().includes('disabled')
+      )
+      if (isIntrospectionDisabled) {
+        return {
+          success: false,
+          message: `GraphQLエンドポイントへの接続は成功しましたが、Introspectionが無効になっています。GraphQL APIの設定を確認してください。`,
+        }
+      }
+      return {
+        success: false,
+        message: `GraphQL接続エラー: ${errorMessages}`,
+      }
+    }
+
+    // data.__schema が存在すれば成功
+    if (data.data?.__schema) {
+      return {
+        success: true,
+        message: 'GraphQL Introspection successful.',
+      }
+    }
+
+    return {
+      success: false,
+      message: 'GraphQLレスポンスの形式が不正です。エンドポイントURLを確認してください。',
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        return {
+          success: false,
+          message: 'GraphQL接続がタイムアウトしました（5秒）。エンドポイントURLを確認してください。',
+        }
+      }
+      console.error('[connectionManager] testGraphQLConnection error:', err)
+      return {
+        success: false,
+        message: `GraphQL接続に失敗しました: ${err.message}`,
+      }
+    }
+    console.error('[connectionManager] testGraphQLConnection unknown error:', err)
+    return {
+      success: false,
+      message: 'GraphQL接続に失敗しました。',
+    }
   }
 }

--- a/output_system/backend/src/services/database.ts
+++ b/output_system/backend/src/services/database.ts
@@ -74,11 +74,11 @@ function getOrCreateConnection(dbConnectionId: string): KnexType {
   const knexInstance = Knex({
     client,
     connection: {
-      host: conn.host,
-      port: conn.port,
-      user: conn.username,
+      host: conn.host ?? undefined,
+      port: conn.port ?? undefined,
+      user: conn.username ?? undefined,
       password: conn.password,
-      database: conn.databaseName,
+      database: conn.databaseName ?? undefined,
     },
     pool: {
       // 最小コネクション数: 0（アイドル時にコネクションを解放）

--- a/output_system/backend/src/services/historyDb.ts
+++ b/output_system/backend/src/services/historyDb.ts
@@ -44,16 +44,28 @@ import fs from 'fs'
  *
  * password_encrypted には AES-256-GCM で暗号化されたパスワードが格納される。
  * 平文パスワードは保存しないこと。
+ *
+ * PBI #200 追加:
+ * - endpoint_url: GraphQL接続先のエンドポイントURL（GraphQL時のみ使用。DB時はNULL）
+ * - host/port/username/password_encrypted/database_name: GraphQL時はNULL許容
  */
 export interface DbConnectionRow {
   id: string
   name: string
+  /** DBタイプ: 'mysql' | 'postgresql' | 'graphql' */
   db_type: string
-  host: string
-  port: number
-  username: string
-  password_encrypted: string
-  database_name: string
+  /** DBホスト名（GraphQL時はNULL） */
+  host: string | null
+  /** DBポート番号（GraphQL時はNULL） */
+  port: number | null
+  /** DBユーザー名（GraphQL時はNULL） */
+  username: string | null
+  /** 暗号化済みパスワード（GraphQL時はNULL） */
+  password_encrypted: string | null
+  /** データベース名（GraphQL時はNULL） */
+  database_name: string | null
+  /** GraphQL接続先エンドポイントURL（DB時はNULL） */
+  endpoint_url: string | null
   is_last_used: number  // SQLite では BOOLEAN は INTEGER（0/1）として保存
   schema_cache: string | null  // SchemaInfo の JSON 文字列（キャッシュ済みスキーマ）
   schema_cached_at: string | null  // スキーマキャッシュの取得日時（ISO 8601）
@@ -232,24 +244,30 @@ function runMigrations(db: Database.Database): void {
   // ===========================================================================
   // - id: UUID（クライアント側で生成）
   // - name: 接続名（表示用）。UNIQUE 制約で重複を防ぐ
-  // - db_type: 'mysql' または 'postgresql'
-  // - host: ホスト名
-  // - port: ポート番号
-  // - username: DBユーザー名
-  // - password_encrypted: AES-256-GCM で暗号化されたパスワード（平文は保存しない）
-  // - database_name: 接続先DBの名前
+  // - db_type: 'mysql' | 'postgresql' | 'graphql'（PBI #200でgraphqlを追加）
+  // - host: ホスト名（GraphQL時はNULL）
+  // - port: ポート番号（GraphQL時はNULL）
+  // - username: DBユーザー名（GraphQL時はNULL）
+  // - password_encrypted: AES-256-GCM で暗号化されたパスワード（GraphQL時はNULL）
+  // - database_name: 接続先DBの名前（GraphQL時はNULL）
+  // - endpoint_url: GraphQL接続先エンドポイントURL（DB時はNULL）（PBI #200追加）
   // - is_last_used: 最後に使用したDB フラグ（0/1）。SQLite では BOOLEAN を INTEGER で表現
   // - created_at / updated_at: ISO 8601 文字列で保存
+  //
+  // GraphQL対応方針（PBI #200）:
+  //   - db_type='graphql' の場合: endpoint_url のみ必須、host/port/username/password/database_name はNULL
+  //   - db_type='mysql'/'postgresql' の場合: 従来通り host/port/username/password/database_name が必須
   db.exec(`
     CREATE TABLE IF NOT EXISTS db_connections (
       id                 TEXT     NOT NULL PRIMARY KEY,
       name               TEXT     NOT NULL UNIQUE,
-      db_type            TEXT     NOT NULL CHECK(db_type IN ('mysql', 'postgresql')),
-      host               TEXT     NOT NULL,
-      port               INTEGER  NOT NULL,
-      username           TEXT     NOT NULL,
-      password_encrypted TEXT     NOT NULL,
-      database_name      TEXT     NOT NULL,
+      db_type            TEXT     NOT NULL CHECK(db_type IN ('mysql', 'postgresql', 'graphql')),
+      host               TEXT,
+      port               INTEGER,
+      username           TEXT,
+      password_encrypted TEXT,
+      database_name      TEXT,
+      endpoint_url       TEXT,
       is_last_used       INTEGER  NOT NULL DEFAULT 0,
       created_at         DATETIME NOT NULL,
       updated_at         DATETIME NOT NULL
@@ -264,6 +282,10 @@ function runMigrations(db: Database.Database): void {
   }
   if (!columnNames.includes('schema_cached_at')) {
     db.exec(`ALTER TABLE db_connections ADD COLUMN schema_cached_at DATETIME DEFAULT NULL`)
+  }
+  // PBI #200: endpoint_url カラムの追加（既存DB互換）
+  if (!columnNames.includes('endpoint_url')) {
+    db.exec(`ALTER TABLE db_connections ADD COLUMN endpoint_url TEXT DEFAULT NULL`)
   }
 
   // ===========================================================================
@@ -621,12 +643,17 @@ export function listMessagesByConversationId(
  * password は必ず暗号化済みのものを渡すこと（平文パスワードは保存しない）。
  * AES-256-GCM 暗号化は呼び出し元（config サービス等）が担当する。
  *
+ * PBI #200: GraphQL接続先に対応。
+ * - db_type='graphql' の場合: endpoint_url が必須。host/port/username/password_encrypted/database_name はNULL可
+ * - db_type='mysql'/'postgresql' の場合: 従来通り（endpoint_url はNULL）
+ *
  * @param db - Database インスタンス
  * @param params - 作成パラメータ
  * @returns 作成された DbConnectionRow
  *
  * @example
  * ```typescript
+ * // DB接続先の作成
  * const conn = createDbConnection(db, {
  *   id: uuidv4(),
  *   name: '本番DB',
@@ -637,6 +664,14 @@ export function listMessagesByConversationId(
  *   password_encrypted: encryptedPassword,
  *   database_name: 'production',
  * })
+ *
+ * // GraphQL接続先の作成
+ * const graphqlConn = createDbConnection(db, {
+ *   id: uuidv4(),
+ *   name: 'My GraphQL API',
+ *   db_type: 'graphql',
+ *   endpoint_url: 'https://api.example.com/graphql',
+ * })
  * ```
  */
 export function createDbConnection(
@@ -645,32 +680,40 @@ export function createDbConnection(
     id: string
     name: string
     db_type: string
-    host: string
-    port: number
-    username: string
-    password_encrypted: string
-    database_name: string
+    /** DBホスト名（GraphQL時はundefined/null可） */
+    host?: string | null
+    /** DBポート番号（GraphQL時はundefined/null可） */
+    port?: number | null
+    /** DBユーザー名（GraphQL時はundefined/null可） */
+    username?: string | null
+    /** 暗号化済みパスワード（GraphQL時はundefined/null可） */
+    password_encrypted?: string | null
+    /** データベース名（GraphQL時はundefined/null可） */
+    database_name?: string | null
+    /** GraphQLエンドポイントURL（DB時はundefined/null可） */
+    endpoint_url?: string | null
   }
 ): DbConnectionRow {
   const now = new Date().toISOString()
   const stmt = db.prepare(`
     INSERT INTO db_connections (
       id, name, db_type, host, port, username, password_encrypted,
-      database_name, is_last_used, created_at, updated_at
+      database_name, endpoint_url, is_last_used, created_at, updated_at
     ) VALUES (
       @id, @name, @db_type, @host, @port, @username, @password_encrypted,
-      @database_name, 0, @created_at, @updated_at
+      @database_name, @endpoint_url, 0, @created_at, @updated_at
     )
   `)
   stmt.run({
     id: params.id,
     name: params.name,
     db_type: params.db_type,
-    host: params.host,
-    port: params.port,
-    username: params.username,
-    password_encrypted: params.password_encrypted,
-    database_name: params.database_name,
+    host: params.host ?? null,
+    port: params.port ?? null,
+    username: params.username ?? null,
+    password_encrypted: params.password_encrypted ?? null,
+    database_name: params.database_name ?? null,
+    endpoint_url: params.endpoint_url ?? null,
     created_at: now,
     updated_at: now,
   })
@@ -690,7 +733,7 @@ export function getDbConnectionById(
 ): DbConnectionRow | undefined {
   const stmt = db.prepare(`
     SELECT id, name, db_type, host, port, username, password_encrypted,
-           database_name, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
+           database_name, endpoint_url, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
     FROM db_connections
     WHERE id = ?
   `)
@@ -706,7 +749,7 @@ export function getDbConnectionById(
 export function listDbConnections(db: Database.Database): DbConnectionRow[] {
   const stmt = db.prepare(`
     SELECT id, name, db_type, host, port, username, password_encrypted,
-           database_name, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
+           database_name, endpoint_url, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
     FROM db_connections
     ORDER BY name ASC
   `)
@@ -771,7 +814,7 @@ export function getLastUsedDbConnection(
 ): DbConnectionRow | undefined {
   const stmt = db.prepare(`
     SELECT id, name, db_type, host, port, username, password_encrypted,
-           database_name, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
+           database_name, endpoint_url, is_last_used, schema_cache, schema_cached_at, created_at, updated_at
     FROM db_connections
     WHERE is_last_used = 1
     ORDER BY updated_at DESC

--- a/output_system/backend/src/services/llm.ts
+++ b/output_system/backend/src/services/llm.ts
@@ -45,8 +45,8 @@ export interface LlmGenerateInput {
   question: string
   /** DBスキーマ情報（INFORMATION_SCHEMA から取得済み） */
   schema: SchemaInfo
-  /** DB種別（mysql / postgresql）。SQL方言の選択に使用 */
-  dbType: 'mysql' | 'postgresql'
+  /** DB種別（mysql / postgresql / graphql）。SQL方言の選択に使用 */
+  dbType: 'mysql' | 'postgresql' | 'graphql'
   /** 会話履歴（直近のやり取り。省略時は単発の質問として扱う） */
   conversationHistory?: ConversationMessage[]
 }
@@ -134,10 +134,35 @@ const REQUEST_TIMEOUT_MS = 60_000
  * DB種別に応じたSQL方言指示を含める。
  * スキーマに含まれるコメント情報の活用を明示的に指示する。
  *
- * @param dbType - DB種別（mysql / postgresql）
+ * @param dbType - DB種別（mysql / postgresql / graphql）
  * @returns システムプロンプト文字列
  */
-function buildSystemPrompt(dbType: 'mysql' | 'postgresql'): string {
+function buildSystemPrompt(dbType: 'mysql' | 'postgresql' | 'graphql'): string {
+  if (dbType === 'graphql') {
+    return `You are a helpful data analyst assistant. Your role is to help users understand and query GraphQL APIs.
+
+DATABASE TYPE: GraphQL
+The connected data source is a GraphQL API. You can help users understand the schema and formulate GraphQL queries.
+
+SCHEMA INFORMATION:
+The user's message always contains a "Database Schema" section that lists ALL available types and fields. This is the complete and authoritative schema of the connected GraphQL API.
+- **NEVER say you don't have schema information. It is ALWAYS provided in the user's message.**
+- **NEVER ask the user to provide type or field information. You already have it.**
+- Use ONLY the types and fields listed in the "Database Schema" section.
+
+RULES:
+1. When the user asks about data, generate a GraphQL query to fetch it.
+2. Format GraphQL queries in the "sql" block (they will be labeled appropriately in the UI).
+3. Choose the most appropriate chart type for visualization:
+   - "bar"  : Category comparisons
+   - "line" : Time series data
+   - "pie"  : Proportional data
+   - "table": Complex data or when no specific chart is appropriate
+
+IMPORTANT: Always try your best to help the user. If the question is vague, make reasonable assumptions based on the available schema.
+`
+  }
+
   const dialectName = dbType === 'mysql' ? 'MySQL' : 'PostgreSQL'
 
   return `You are a helpful data analyst assistant. Your role is to translate natural language questions into SQL queries for data visualization.

--- a/output_system/backend/src/services/schema.ts
+++ b/output_system/backend/src/services/schema.ts
@@ -10,14 +10,19 @@
  *   - メモリキャッシュ: Map<dbConnectionId, SchemaInfo> でキャッシュを保持
  *   - キャッシュ無効化: invalidateSchemaCache() を公開し、接続先更新・削除時に呼ぶ
  *
+ * PBI #200 追加:
+ *   - GraphQL接続先のIntrospection Query対応
+ *   - dbType='graphql' の場合: Introspection Query でスキーマを取得し SchemaInfo 形式に変換
+ *   - ビルトイン型（__で始まる型）は除外する
+ *
  * レスポンス形式は api.md の /api/schema と同一:
  * {
  *   database: string,
- *   tables: [
+ *   tables: [  ← GraphQLの場合はTypeを表す
  *     {
  *       name: string,
  *       comment: string | null,
- *       columns: [
+ *       columns: [  ← GraphQLの場合はFieldを表す
  *         { name: string, type: string, nullable: boolean, comment: string | null }
  *       ]
  *     }
@@ -25,7 +30,7 @@
  * }
  *
  * セキュリティ注意事項:
- *   - このサービスは SELECT のみを実行する（リードオンリー）
+ *   - このサービスは SELECT（DB）またはIntrospection（GraphQL）のみを実行する（リードオンリー）
  *   - DBユーザーにはリードオンリー権限（SELECT のみ）を付与することを推奨
  */
 
@@ -48,10 +53,15 @@ export interface TableInfo {
   columns: ColumnInfo[]
 }
 
-/** スキーマ情報レスポンス */
+/**
+ * スキーマ情報レスポンス
+ *
+ * PBI #200: dbType に 'graphql' を追加
+ * GraphQLの場合: database はエンドポイントURL、tables はGraphQLのType/Field情報
+ */
 export interface SchemaInfo {
   database: string
-  dbType: 'mysql' | 'postgresql'
+  dbType: 'mysql' | 'postgresql' | 'graphql'
   tables: TableInfo[]
 }
 
@@ -143,14 +153,21 @@ function buildDynamicKnex(dbConnectionId: string): {
     throw new Error(`Unsupported DB type: ${conn.dbType}`)
   }
 
+  // DB接続には host/port/username/databaseName が必要（GraphQL時はここに来ない想定）
+  // null の場合はエラーを出す（DB型のみが buildDynamicKnex を呼ぶ）
+  const host = conn.host ?? ''
+  const port = conn.port ?? 0
+  const username = conn.username ?? ''
+  const databaseName = conn.databaseName ?? ''
+
   const knexInstance = Knex({
     client,
     connection: {
-      host: conn.host,
-      port: conn.port,
-      user: conn.username,
+      host,
+      port,
+      user: username,
       password: conn.password,
-      database: conn.databaseName,
+      database: databaseName,
       // MySQL: INFORMATION_SCHEMA のコメント情報を文字化けなく取得するために charset を指定
       ...(conn.dbType === 'mysql' ? { charset: 'utf8mb4' } : {}),
     },
@@ -159,7 +176,172 @@ function buildDynamicKnex(dbConnectionId: string): {
     debug: false,
   })
 
-  return { knex: knexInstance, databaseName: conn.databaseName, dbType: conn.dbType }
+  return { knex: knexInstance, databaseName, dbType: conn.dbType }
+}
+
+// =============================================================================
+// GraphQL Introspectionスキーマ取得
+// =============================================================================
+
+/**
+ * GraphQL IntrospectionのTypeエントリ型（内部型）
+ */
+interface GraphQLIntrospectionField {
+  name: string
+  type: {
+    name: string | null
+    kind: string
+    ofType: {
+      name: string | null
+      kind: string
+    } | null
+  }
+}
+
+/**
+ * GraphQL IntrospectionのTypeエントリ型（内部型）
+ */
+interface GraphQLIntrospectionType {
+  name: string
+  kind: string
+  fields: GraphQLIntrospectionField[] | null
+}
+
+/**
+ * GraphQL Introspection Query のレスポンス型（内部型）
+ */
+interface GraphQLIntrospectionResponse {
+  data?: {
+    __schema?: {
+      types: GraphQLIntrospectionType[]
+    }
+  }
+  errors?: Array<{ message: string }>
+}
+
+/**
+ * GraphQL型の実際の型名を解決する
+ *
+ * GraphQLの型は NON_NULL / LIST でラップされることがある。
+ * ofType を再帰的に辿って実際の型名を取得する。
+ *
+ * @param type - GraphQL型オブジェクト
+ * @returns 解決された型名文字列
+ *
+ * @example
+ * ```
+ * resolveTypeName({ name: null, kind: 'NON_NULL', ofType: { name: 'String', kind: 'SCALAR' } })
+ * // => 'String!'
+ * resolveTypeName({ name: null, kind: 'LIST', ofType: { name: 'User', kind: 'OBJECT' } })
+ * // => '[User]'
+ * ```
+ */
+function resolveTypeName(type: { name: string | null; kind: string; ofType: { name: string | null; kind: string } | null }): string {
+  if (type.kind === 'NON_NULL') {
+    const inner = type.ofType ? resolveTypeName(type.ofType as { name: string | null; kind: string; ofType: null }) : 'Unknown'
+    return `${inner}!`
+  }
+  if (type.kind === 'LIST') {
+    const inner = type.ofType ? resolveTypeName(type.ofType as { name: string | null; kind: string; ofType: null }) : 'Unknown'
+    return `[${inner}]`
+  }
+  return type.name ?? 'Unknown'
+}
+
+/**
+ * GraphQL Introspection Query を実行してスキーマ情報を取得する
+ *
+ * フルIntrospection Query（types.fields を含む）を実行し、
+ * OBJECT/INTERFACE/INPUT_OBJECT 型とそのフィールドを SchemaInfo 形式に変換する。
+ * ビルトイン型（__ プレフィックス）と SCALAR/ENUM/UNION は除外する。
+ *
+ * @param endpointUrl - GraphQLエンドポイントURL
+ * @returns SchemaInfo 形式のスキーマ情報
+ * @throws Error - 接続失敗またはIntrospection無効の場合
+ */
+async function fetchSchemaGraphQL(endpointUrl: string): Promise<SchemaInfo> {
+  // フルIntrospection Query（フィールド・引数・型情報を含む）
+  const introspectionQuery = `
+    {
+      __schema {
+        types {
+          name
+          kind
+          fields {
+            name
+            type {
+              name
+              kind
+              ofType {
+                name
+                kind
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const response = await fetch(endpointUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify({ query: introspectionQuery }),
+    // タイムアウト: 10秒（フルIntrospectionはデータ量が多いため接続テストより長め）
+    signal: AbortSignal.timeout(10000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`GraphQL接続に失敗しました: HTTP ${response.status} ${response.statusText}`)
+  }
+
+  const data = await response.json() as GraphQLIntrospectionResponse
+
+  if (data.errors && data.errors.length > 0) {
+    const errorMessages = data.errors.map((e) => e.message).join('; ')
+    throw new Error(`GraphQL Introspection エラー: ${errorMessages}`)
+  }
+
+  const types = data.data?.__schema?.types ?? []
+
+  // OBJECT/INTERFACE/INPUT_OBJECT 型のみを対象（SCALAR, ENUM, UNION, ビルトイン型は除外）
+  // ビルトイン型の除外基準: 名前が '__' で始まるもの
+  const filteredTypes = types.filter(
+    (type) =>
+      (type.kind === 'OBJECT' || type.kind === 'INTERFACE' || type.kind === 'INPUT_OBJECT') &&
+      !type.name.startsWith('__')
+  )
+
+  // SchemaInfo.tables 形式に変換（GraphQLのTypeをtableとして扱う）
+  const tables: TableInfo[] = filteredTypes
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((type) => {
+      const columns: ColumnInfo[] = (type.fields ?? []).map((field) => ({
+        name: field.name,
+        // 型名を解決（NON_NULL / LIST のラップを解除）
+        type: resolveTypeName(field.type),
+        // NON_NULL でラップされていればnon-nullable（必須）
+        nullable: field.type.kind !== 'NON_NULL',
+        comment: null,
+      }))
+
+      return {
+        name: type.name,
+        // GraphQLではコメント（description）を取得していないためnull
+        comment: null,
+        columns,
+      }
+    })
+
+  return {
+    // GraphQLの場合: databaseにエンドポイントURLを設定
+    database: endpointUrl,
+    dbType: 'graphql',
+    tables,
+  }
 }
 
 // =============================================================================
@@ -261,7 +443,7 @@ async function fetchSchemaMysql(
 export function buildSchemaInfo(
   database: string,
   rows: InformationSchemaColumn[],
-  dbType: 'mysql' | 'postgresql' = 'mysql'
+  dbType: 'mysql' | 'postgresql' | 'graphql' = 'mysql'
 ): SchemaInfo {
   // テーブル名をキーとしたMapを使い、カラムとテーブルコメントをグループ化
   const tableMap = new Map<string, { comment: string | null; columns: ColumnInfo[] }>()
@@ -342,18 +524,51 @@ export async function fetchSchema(dbConnectionId: string): Promise<SchemaInfo> {
 }
 
 /**
- * 指定DB接続先のスキーマをDBから再取得し、永続キャッシュとメモリキャッシュの両方を更新する
+ * 指定DB/GraphQL接続先のスキーマをDBから再取得し、永続キャッシュとメモリキャッシュの両方を更新する
  *
  * 接続登録時やユーザーの手動リフレッシュ時に呼び出す。
  *
- * @param dbConnectionId - DB接続先ID（UUID）
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: Introspection Query でスキーマを取得
+ * - dbType='mysql'/'postgresql' の場合: 従来通り INFORMATION_SCHEMA から取得
+ *
+ * @param dbConnectionId - DB/GraphQL接続先ID（UUID）
  * @returns 再取得したスキーマ情報
  * @throws ConnectionNotFoundError 接続先が見つからない場合
- * @throws Error DB接続失敗またはクエリエラー
+ * @throws Error DB/GraphQL接続失敗またはクエリエラー
  */
 export async function refreshSchema(dbConnectionId: string): Promise<SchemaInfo> {
   console.info(`[schema] Fetching schema from DB for dbConnectionId: ${dbConnectionId}`)
 
+  // GraphQL接続先かどうかを確認（接続先情報を取得）
+  const conn = getById(dbConnectionId)
+
+  if (conn.dbType === 'graphql') {
+    // GraphQL接続先: Introspection Query でスキーマを取得
+    if (!conn.endpointUrl) {
+      throw new Error(`GraphQL接続先のendpointUrlが設定されていません: ${dbConnectionId}`)
+    }
+
+    const schemaInfo = await fetchSchemaGraphQL(conn.endpointUrl)
+
+    // メモリキャッシュに保存
+    schemaCache.set(dbConnectionId, schemaInfo)
+
+    // SQLite 永続キャッシュに保存
+    try {
+      const db = getHistoryDb()
+      updateDbConnectionSchemaCache(db, dbConnectionId, JSON.stringify(schemaInfo))
+      console.info(
+        `[schema] GraphQL schema persisted for dbConnectionId: ${dbConnectionId} (${schemaInfo.tables.length} types)`
+      )
+    } catch (err) {
+      console.warn('[schema] Failed to persist GraphQL schema cache (non-fatal):', err)
+    }
+
+    return schemaInfo
+  }
+
+  // DB接続先（MySQL/PostgreSQL）: 従来通りINFORMATION_SCHEMAから取得
   let knexInstance: KnexType | null = null
   try {
     const { knex, databaseName, dbType } = buildDynamicKnex(dbConnectionId)

--- a/output_system/backend/src/types/index.ts
+++ b/output_system/backend/src/types/index.ts
@@ -18,8 +18,10 @@
 /**
  * サポートするデータベースタイプ
  * knex.js のクライアント識別子に対応する
+ *
+ * PBI #200: 'graphql' を追加（GraphQL APIのIntrospection対応）
  */
-export type DbType = 'postgresql' | 'mysql'
+export type DbType = 'postgresql' | 'mysql' | 'graphql'
 
 /**
  * DB接続設定

--- a/output_system/frontend/src/App.tsx
+++ b/output_system/frontend/src/App.tsx
@@ -303,6 +303,7 @@ const App: FC = () => {
             >
               {connections.map((conn) => (
                 <option key={conn.id} value={conn.id}>
+                  {/* PBI #200: GraphQL接続先は「接続名 (graphql)」形式で表示 */}
                   {conn.name} ({conn.dbType})
                 </option>
               ))}

--- a/output_system/frontend/src/components/DbManagement/DbConnectionForm.tsx
+++ b/output_system/frontend/src/components/DbManagement/DbConnectionForm.tsx
@@ -5,8 +5,11 @@
  * 新規登録時は空のフォームを表示し、編集時は既存値を初期値として表示する。
  *
  * 機能:
- * - 接続名・DB種別・ホスト・ポート・ユーザー名・パスワード・DB名の入力
- * - フォームバリデーション（必須フィールドチェック・ポート番号範囲チェック）
+ * - 接続名・DB種別・ホスト・ポート・ユーザー名・パスワード・DB名の入力（MySQL/PostgreSQL時）
+ * - 接続名・DB種別・エンドポイントURLの入力（GraphQL時）
+ * - DB種別で「GraphQL」選択時: ホスト/ポート/ユーザー/パスワード/DB名フィールドを非表示
+ * - DB種別で「GraphQL」選択時: エンドポイントURL入力フィールドを表示
+ * - フォームバリデーション（必須フィールドチェック・ポート番号範囲チェック・URL形式チェック）
  * - 「接続テスト」ボタン: 入力値でバックエンドに接続を試行し、結果をToastで表示
  * - 「保存」ボタン: バリデーション通過後に onSave を呼び出す
  * - 「キャンセル」ボタン: 変更を破棄して onCancel を呼び出す
@@ -15,10 +18,12 @@
  * - 制御されたコンポーネント（controlled component）でフォーム状態を管理
  * - バリデーションエラーはフィールド単位で表示
  * - 接続テスト中・保存中はボタンを無効化してUI操作を防ぐ
+ * - DB種別が変わると必要なフィールドだけを表示する（条件付きレンダリング）
  *
  * 参考: screens.md DB管理モーダル ワイヤーフレーム
  *
  * PBI #148 追加
+ * PBI #200 改修: GraphQLフォーム切替対応
  */
 
 import { useState, useCallback, useEffect, type FC, type FormEvent, type ChangeEvent } from 'react'
@@ -51,8 +56,9 @@ interface DbConnectionFormProps {
 
 /**
  * DB種別ごとのデフォルトポート番号
+ * graphql はポートを使用しないためundefined
  */
-const DEFAULT_PORTS: Record<DbType, number> = {
+const DEFAULT_PORTS: Partial<Record<DbType, number>> = {
   mysql: 3306,
   postgresql: 5432,
 }
@@ -68,6 +74,7 @@ const INITIAL_FORM_VALUES: DbConnectionInput = {
   username: '',
   password: '',
   databaseName: '',
+  endpointUrl: '',
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +84,8 @@ const INITIAL_FORM_VALUES: DbConnectionInput = {
 /**
  * フォームバリデーションエラーの型
  * 各フィールドのエラーメッセージを保持する（エラーなしは空文字）。
+ *
+ * PBI #200: endpointUrl フィールドのエラーを追加
  */
 interface FormErrors {
   name: string
@@ -85,13 +94,19 @@ interface FormErrors {
   username: string
   password: string
   databaseName: string
+  /** GraphQL接続時のエンドポイントURLエラー */
+  endpointUrl: string
 }
 
 /**
  * フォームの入力値をバリデーションする
  *
+ * DB種別によってバリデーションルールを切り替える:
+ * - GraphQL: endpointUrl が必須（URL形式チェック）
+ * - MySQL/PostgreSQL: host/port/username/databaseName が必須
+ *
  * @param values - バリデーション対象のフォーム値
- * @param isEdit - 編集モードかどうか（編集時はパスワード空許容）
+ * @param isEdit - 編集モードかどうか（DB接続の編集時はパスワード空許容）
  * @returns バリデーションエラー（全フィールドエラーなしなら全て空文字）
  */
 function validateForm(values: DbConnectionInput, isEdit: boolean): FormErrors {
@@ -102,41 +117,59 @@ function validateForm(values: DbConnectionInput, isEdit: boolean): FormErrors {
     username: '',
     password: '',
     databaseName: '',
+    endpointUrl: '',
   }
 
-  // 接続名: 必須・最大100文字
+  // 接続名: 必須・最大100文字（全種別共通）
   if (!values.name.trim()) {
     errors.name = '接続名は必須です'
   } else if (values.name.trim().length > 100) {
     errors.name = '接続名は100文字以内で入力してください'
   }
 
-  // ホスト名: 必須
-  if (!values.host.trim()) {
-    errors.host = 'ホスト名は必須です'
-  }
+  if (values.dbType === 'graphql') {
+    // GraphQL接続のバリデーション: endpointUrl が必須・URL形式チェック
+    if (!values.endpointUrl?.trim()) {
+      errors.endpointUrl = 'エンドポイントURLは必須です'
+    } else {
+      try {
+        const url = new URL(values.endpointUrl.trim())
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          errors.endpointUrl = 'エンドポイントURLは http:// または https:// で始まる必要があります'
+        }
+      } catch {
+        errors.endpointUrl = '有効なURL形式で入力してください（例: https://api.example.com/graphql）'
+      }
+    }
+  } else {
+    // DB接続（MySQL/PostgreSQL）のバリデーション: 従来通り
+    // ホスト名: 必須
+    if (!values.host?.trim()) {
+      errors.host = 'ホスト名は必須です'
+    }
 
-  // ポート番号: 必須・1〜65535の範囲
-  const portNum = Number(values.port)
-  if (!values.port && values.port !== 0) {
-    errors.port = 'ポート番号は必須です'
-  } else if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
-    errors.port = 'ポート番号は1〜65535の整数を入力してください'
-  }
+    // ポート番号: 必須・1〜65535の範囲
+    const portNum = Number(values.port)
+    if (!values.port && values.port !== 0) {
+      errors.port = 'ポート番号は必須です'
+    } else if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+      errors.port = 'ポート番号は1〜65535の整数を入力してください'
+    }
 
-  // ユーザー名: 必須
-  if (!values.username.trim()) {
-    errors.username = 'ユーザー名は必須です'
-  }
+    // ユーザー名: 必須
+    if (!values.username?.trim()) {
+      errors.username = 'ユーザー名は必須です'
+    }
 
-  // パスワード: 新規登録時は必須。編集時は空を許容（空の場合は変更なし）
-  if (!isEdit && !values.password) {
-    errors.password = 'パスワードは必須です'
-  }
+    // パスワード: 新規登録時は必須。編集時は空を許容（空の場合は変更なし）
+    if (!isEdit && !values.password) {
+      errors.password = 'パスワードは必須です'
+    }
 
-  // DB名: 必須
-  if (!values.databaseName.trim()) {
-    errors.databaseName = 'データベース名は必須です'
+    // DB名: 必須
+    if (!values.databaseName?.trim()) {
+      errors.databaseName = 'データベース名は必須です'
+    }
   }
 
   return errors
@@ -159,6 +192,9 @@ function hasErrors(errors: FormErrors): boolean {
 /**
  * DB接続先登録・編集フォームコンポーネント
  *
+ * DB種別ドロップダウンで「GraphQL」を選択すると、ホスト/ポート/ユーザー等の
+ * フィールドが非表示になり、エンドポイントURL入力フィールドが表示される。
+ *
  * @param props - DbConnectionFormProps
  */
 const DbConnectionForm: FC<DbConnectionFormProps> = ({
@@ -175,14 +211,24 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
   const [values, setValues] = useState<DbConnectionInput>(() => {
     if (connection) {
       // 編集モード: 既存値を初期値として設定（パスワードは空にする）
+      if (connection.dbType === 'graphql') {
+        // GraphQL接続先の編集
+        return {
+          name: connection.name,
+          dbType: 'graphql',
+          endpointUrl: connection.endpointUrl ?? '',
+        }
+      }
+      // DB接続先（MySQL/PostgreSQL）の編集
       return {
         name: connection.name,
         dbType: connection.dbType,
-        host: connection.host,
-        port: connection.port,
-        username: connection.username,
+        host: connection.host ?? '',
+        port: connection.port ?? DEFAULT_PORTS[connection.dbType] ?? 3306,
+        username: connection.username ?? '',
         password: '', // セキュリティ上、既存パスワードは表示しない
-        databaseName: connection.databaseName,
+        databaseName: connection.databaseName ?? '',
+        endpointUrl: '',
       }
     }
     // 新規登録モード: 空の初期値
@@ -197,6 +243,7 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
     username: '',
     password: '',
     databaseName: '',
+    endpointUrl: '',
   })
 
   // 送信が試みられたかどうか（初回送信前はエラー非表示）
@@ -206,24 +253,38 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
   const [isTesting, setIsTesting] = useState(false)
 
   /**
+   * GraphQL接続かどうかの判定（フィールド表示切替に使用）
+   */
+  const isGraphQL = values.dbType === 'graphql'
+
+  /**
    * connection が変わった場合（別のエントリの編集に切り替え）はフォームをリセット
    */
   useEffect(() => {
     if (connection) {
-      setValues({
-        name: connection.name,
-        dbType: connection.dbType,
-        host: connection.host,
-        port: connection.port,
-        username: connection.username,
-        password: '', // セキュリティ上、既存パスワードは表示しない
-        databaseName: connection.databaseName,
-      })
+      if (connection.dbType === 'graphql') {
+        setValues({
+          name: connection.name,
+          dbType: 'graphql',
+          endpointUrl: connection.endpointUrl ?? '',
+        })
+      } else {
+        setValues({
+          name: connection.name,
+          dbType: connection.dbType,
+          host: connection.host ?? '',
+          port: connection.port ?? DEFAULT_PORTS[connection.dbType] ?? 3306,
+          username: connection.username ?? '',
+          password: '', // セキュリティ上、既存パスワードは表示しない
+          databaseName: connection.databaseName ?? '',
+          endpointUrl: '',
+        })
+      }
     } else {
       setValues({ ...INITIAL_FORM_VALUES })
     }
     // フォームリセット時はエラーと送信フラグもクリア
-    setErrors({ name: '', host: '', port: '', username: '', password: '', databaseName: '' })
+    setErrors({ name: '', host: '', port: '', username: '', password: '', databaseName: '', endpointUrl: '' })
     setSubmitted(false)
   }, [connection])
 
@@ -231,6 +292,8 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
    * テキスト・セレクト入力の変更ハンドラ（汎用）
    *
    * DB種別が変更された場合はデフォルトポートも自動更新する。
+   * GraphQL に切り替えた場合は DB固有フィールドをクリアし、
+   * DB（MySQL/PostgreSQL）に切り替えた場合は endpointUrl をクリアする。
    *
    * @param e - 変更イベント
    */
@@ -240,9 +303,21 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
 
       setValues((prev) => {
         const next = { ...prev, [name]: value }
-        // DB種別が変わったらデフォルトポートを自動設定
+        // DB種別が変わったらデフォルトポートを自動設定 and フィールドをリセット
         if (name === 'dbType') {
-          next.port = DEFAULT_PORTS[value as DbType]
+          if (value === 'graphql') {
+            // GraphQL選択時: DB固有フィールドをクリア
+            next.host = ''
+            next.port = undefined
+            next.username = ''
+            next.password = ''
+            next.databaseName = ''
+            next.endpointUrl = next.endpointUrl ?? ''
+          } else {
+            // DB選択時: GraphQL固有フィールドをクリアし、デフォルトポートを設定
+            next.endpointUrl = ''
+            next.port = DEFAULT_PORTS[value as DbType] ?? 3306
+          }
         }
         return next
       })
@@ -309,7 +384,7 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
         {isEdit ? '接続先を編集' : '新しい接続先を追加'}
       </h3>
 
-      {/* 接続名 */}
+      {/* 接続名（全種別共通） */}
       <div className="form-field">
         <label htmlFor="conn-name" className="form-field__label">
           接続名 <span className="form-field__required" aria-label="必須">*</span>
@@ -334,7 +409,7 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
         )}
       </div>
 
-      {/* DB種別 */}
+      {/* DB種別（全種別共通） */}
       <div className="form-field">
         <label htmlFor="conn-db-type" className="form-field__label">
           DB種別 <span className="form-field__required" aria-label="必須">*</span>
@@ -350,137 +425,184 @@ const DbConnectionForm: FC<DbConnectionFormProps> = ({
         >
           <option value="mysql">MySQL</option>
           <option value="postgresql">PostgreSQL</option>
+          {/* PBI #200: GraphQL接続先オプションを追加 */}
+          <option value="graphql">GraphQL</option>
         </select>
       </div>
 
-      {/* ホスト名 */}
-      <div className="form-field">
-        <label htmlFor="conn-host" className="form-field__label">
-          ホスト名 <span className="form-field__required" aria-label="必須">*</span>
-        </label>
-        <input
-          id="conn-host"
-          type="text"
-          name="host"
-          className={`form-field__input${errors.host && submitted ? ' form-field__input--error' : ''}`}
-          value={values.host}
-          onChange={handleChange}
-          placeholder="例: db-server または 192.168.1.1"
-          disabled={isDisabled}
-          aria-describedby={errors.host && submitted ? 'conn-host-error' : undefined}
-          aria-required="true"
-        />
-        {errors.host && submitted && (
-          <p id="conn-host-error" className="form-field__error" role="alert">
-            {errors.host}
-          </p>
-        )}
-      </div>
-
-      {/* ポート番号 */}
-      <div className="form-field">
-        <label htmlFor="conn-port" className="form-field__label">
-          ポート番号 <span className="form-field__required" aria-label="必須">*</span>
-        </label>
-        <input
-          id="conn-port"
-          type="number"
-          name="port"
-          className={`form-field__input form-field__input--port${errors.port && submitted ? ' form-field__input--error' : ''}`}
-          value={values.port}
-          onChange={handleChange}
-          min={1}
-          max={65535}
-          disabled={isDisabled}
-          aria-describedby={errors.port && submitted ? 'conn-port-error' : undefined}
-          aria-required="true"
-        />
-        {errors.port && submitted && (
-          <p id="conn-port-error" className="form-field__error" role="alert">
-            {errors.port}
-          </p>
-        )}
-      </div>
-
-      {/* ユーザー名 */}
-      <div className="form-field">
-        <label htmlFor="conn-username" className="form-field__label">
-          ユーザー名 <span className="form-field__required" aria-label="必須">*</span>
-        </label>
-        <input
-          id="conn-username"
-          type="text"
-          name="username"
-          className={`form-field__input${errors.username && submitted ? ' form-field__input--error' : ''}`}
-          value={values.username}
-          onChange={handleChange}
-          placeholder="例: readonly_user"
-          disabled={isDisabled}
-          aria-describedby={errors.username && submitted ? 'conn-username-error' : undefined}
-          aria-required="true"
-          autoComplete="username"
-        />
-        {errors.username && submitted && (
-          <p id="conn-username-error" className="form-field__error" role="alert">
-            {errors.username}
-          </p>
-        )}
-      </div>
-
-      {/* パスワード */}
-      <div className="form-field">
-        <label htmlFor="conn-password" className="form-field__label">
-          パスワード
-          {!isEdit && (
-            <span className="form-field__required" aria-label="必須">*</span>
+      {/*
+       * GraphQL接続時のフィールド（PBI #200 追加）
+       *
+       * DB種別が「GraphQL」の場合のみ表示する。
+       * ホスト/ポート/ユーザー/パスワード/DB名フィールドは非表示になる。
+       */}
+      {isGraphQL && (
+        <div className="form-field">
+          <label htmlFor="conn-endpoint-url" className="form-field__label">
+            エンドポイントURL <span className="form-field__required" aria-label="必須">*</span>
+          </label>
+          <input
+            id="conn-endpoint-url"
+            type="url"
+            name="endpointUrl"
+            className={`form-field__input${errors.endpointUrl && submitted ? ' form-field__input--error' : ''}`}
+            value={values.endpointUrl ?? ''}
+            onChange={handleChange}
+            placeholder="例: https://api.example.com/graphql"
+            disabled={isDisabled}
+            aria-describedby={errors.endpointUrl && submitted ? 'conn-endpoint-url-error' : undefined}
+            aria-required="true"
+          />
+          {errors.endpointUrl && submitted && (
+            <p id="conn-endpoint-url-error" className="form-field__error" role="alert">
+              {errors.endpointUrl}
+            </p>
           )}
-          {isEdit && (
-            <span className="form-field__hint">（空の場合は変更しない）</span>
-          )}
-        </label>
-        <input
-          id="conn-password"
-          type="password"
-          name="password"
-          className={`form-field__input${errors.password && submitted ? ' form-field__input--error' : ''}`}
-          value={values.password}
-          onChange={handleChange}
-          placeholder={isEdit ? '変更する場合のみ入力' : 'パスワードを入力'}
-          disabled={isDisabled}
-          aria-describedby={errors.password && submitted ? 'conn-password-error' : undefined}
-          aria-required={!isEdit}
-          autoComplete={isEdit ? 'current-password' : 'new-password'}
-        />
-        {errors.password && submitted && (
-          <p id="conn-password-error" className="form-field__error" role="alert">
-            {errors.password}
+          {/* GraphQL接続のヒント */}
+          <p className="form-field__hint">
+            GraphQL APIのエンドポイントURLを入力してください。接続テストでIntrospection Queryが実行されます。
           </p>
-        )}
-      </div>
+        </div>
+      )}
 
-      {/* データベース名 */}
-      <div className="form-field">
-        <label htmlFor="conn-db-name" className="form-field__label">
-          データベース名 <span className="form-field__required" aria-label="必須">*</span>
-        </label>
-        <input
-          id="conn-db-name"
-          type="text"
-          name="databaseName"
-          className={`form-field__input${errors.databaseName && submitted ? ' form-field__input--error' : ''}`}
-          value={values.databaseName}
-          onChange={handleChange}
-          placeholder="例: sampledb"
-          disabled={isDisabled}
-          aria-describedby={errors.databaseName && submitted ? 'conn-db-name-error' : undefined}
-          aria-required="true"
-        />
-        {errors.databaseName && submitted && (
-          <p id="conn-db-name-error" className="form-field__error" role="alert">
-            {errors.databaseName}
-          </p>
-        )}
-      </div>
+      {/*
+       * DB接続（MySQL/PostgreSQL）時のフィールド
+       *
+       * DB種別が「MySQL」または「PostgreSQL」の場合のみ表示する。
+       * GraphQL選択時はこのブロック全体が非表示になる。
+       */}
+      {!isGraphQL && (
+        <>
+          {/* ホスト名 */}
+          <div className="form-field">
+            <label htmlFor="conn-host" className="form-field__label">
+              ホスト名 <span className="form-field__required" aria-label="必須">*</span>
+            </label>
+            <input
+              id="conn-host"
+              type="text"
+              name="host"
+              className={`form-field__input${errors.host && submitted ? ' form-field__input--error' : ''}`}
+              value={values.host ?? ''}
+              onChange={handleChange}
+              placeholder="例: db-server または 192.168.1.1"
+              disabled={isDisabled}
+              aria-describedby={errors.host && submitted ? 'conn-host-error' : undefined}
+              aria-required="true"
+            />
+            {errors.host && submitted && (
+              <p id="conn-host-error" className="form-field__error" role="alert">
+                {errors.host}
+              </p>
+            )}
+          </div>
+
+          {/* ポート番号 */}
+          <div className="form-field">
+            <label htmlFor="conn-port" className="form-field__label">
+              ポート番号 <span className="form-field__required" aria-label="必須">*</span>
+            </label>
+            <input
+              id="conn-port"
+              type="number"
+              name="port"
+              className={`form-field__input form-field__input--port${errors.port && submitted ? ' form-field__input--error' : ''}`}
+              value={values.port ?? ''}
+              onChange={handleChange}
+              min={1}
+              max={65535}
+              disabled={isDisabled}
+              aria-describedby={errors.port && submitted ? 'conn-port-error' : undefined}
+              aria-required="true"
+            />
+            {errors.port && submitted && (
+              <p id="conn-port-error" className="form-field__error" role="alert">
+                {errors.port}
+              </p>
+            )}
+          </div>
+
+          {/* ユーザー名 */}
+          <div className="form-field">
+            <label htmlFor="conn-username" className="form-field__label">
+              ユーザー名 <span className="form-field__required" aria-label="必須">*</span>
+            </label>
+            <input
+              id="conn-username"
+              type="text"
+              name="username"
+              className={`form-field__input${errors.username && submitted ? ' form-field__input--error' : ''}`}
+              value={values.username ?? ''}
+              onChange={handleChange}
+              placeholder="例: readonly_user"
+              disabled={isDisabled}
+              aria-describedby={errors.username && submitted ? 'conn-username-error' : undefined}
+              aria-required="true"
+              autoComplete="username"
+            />
+            {errors.username && submitted && (
+              <p id="conn-username-error" className="form-field__error" role="alert">
+                {errors.username}
+              </p>
+            )}
+          </div>
+
+          {/* パスワード */}
+          <div className="form-field">
+            <label htmlFor="conn-password" className="form-field__label">
+              パスワード
+              {!isEdit && (
+                <span className="form-field__required" aria-label="必須">*</span>
+              )}
+              {isEdit && (
+                <span className="form-field__hint">（空の場合は変更しない）</span>
+              )}
+            </label>
+            <input
+              id="conn-password"
+              type="password"
+              name="password"
+              className={`form-field__input${errors.password && submitted ? ' form-field__input--error' : ''}`}
+              value={values.password ?? ''}
+              onChange={handleChange}
+              placeholder={isEdit ? '変更する場合のみ入力' : 'パスワードを入力'}
+              disabled={isDisabled}
+              aria-describedby={errors.password && submitted ? 'conn-password-error' : undefined}
+              aria-required={!isEdit}
+              autoComplete={isEdit ? 'current-password' : 'new-password'}
+            />
+            {errors.password && submitted && (
+              <p id="conn-password-error" className="form-field__error" role="alert">
+                {errors.password}
+              </p>
+            )}
+          </div>
+
+          {/* データベース名 */}
+          <div className="form-field">
+            <label htmlFor="conn-db-name" className="form-field__label">
+              データベース名 <span className="form-field__required" aria-label="必須">*</span>
+            </label>
+            <input
+              id="conn-db-name"
+              type="text"
+              name="databaseName"
+              className={`form-field__input${errors.databaseName && submitted ? ' form-field__input--error' : ''}`}
+              value={values.databaseName ?? ''}
+              onChange={handleChange}
+              placeholder="例: sampledb"
+              disabled={isDisabled}
+              aria-describedby={errors.databaseName && submitted ? 'conn-db-name-error' : undefined}
+              aria-required="true"
+            />
+            {errors.databaseName && submitted && (
+              <p id="conn-db-name-error" className="form-field__error" role="alert">
+                {errors.databaseName}
+              </p>
+            )}
+          </div>
+        </>
+      )}
 
       {/* アクションボタン */}
       <div className="db-connection-form__actions">

--- a/output_system/frontend/src/components/DbManagement/DbConnectionList.tsx
+++ b/output_system/frontend/src/components/DbManagement/DbConnectionList.tsx
@@ -93,7 +93,9 @@ const DbConnectionList: FC<DbConnectionListProps> = ({
   /**
    * DB種別の表示ラベルを返す
    *
-   * @param dbType - DB種別（'mysql' | 'postgresql'）
+   * PBI #200: 'graphql' を追加
+   *
+   * @param dbType - DB種別（'mysql' | 'postgresql' | 'graphql'）
    * @returns 表示用ラベル
    */
   const getDbTypeLabel = (dbType: string): string => {
@@ -102,6 +104,8 @@ const DbConnectionList: FC<DbConnectionListProps> = ({
         return 'MySQL'
       case 'postgresql':
         return 'PostgreSQL'
+      case 'graphql':
+        return 'GraphQL'
       default:
         return dbType
     }
@@ -169,21 +173,41 @@ const DbConnectionList: FC<DbConnectionListProps> = ({
                       </span>
                     )}
                   </div>
-                  {/* 接続詳細（DB種別 / ホスト:ポート / DB名） */}
+                  {/*
+                   * 接続詳細（DB種別 / ホスト:ポート / DB名）
+                   *
+                   * PBI #200: GraphQL接続先は「GraphQL / エンドポイントURL」形式で表示
+                   * DB接続先は従来通り「MySQL/PostgreSQL / ホスト:ポート / DB名」形式で表示
+                   */}
                   <div className="db-connection-item__detail">
                     <span className="db-connection-item__db-type">
                       {getDbTypeLabel(conn.dbType)}
                     </span>
-                    <span className="db-connection-item__separator" aria-hidden="true">
-                      /
-                    </span>
-                    <span className="db-connection-item__host">
-                      {conn.host}:{conn.port}
-                    </span>
-                    <span className="db-connection-item__separator" aria-hidden="true">
-                      /
-                    </span>
-                    <span className="db-connection-item__db-name">{conn.databaseName}</span>
+                    {conn.dbType === 'graphql' ? (
+                      // GraphQL接続先: エンドポイントURLを表示
+                      <>
+                        <span className="db-connection-item__separator" aria-hidden="true">
+                          /
+                        </span>
+                        <span className="db-connection-item__endpoint-url" title={conn.endpointUrl ?? ''}>
+                          {conn.endpointUrl}
+                        </span>
+                      </>
+                    ) : (
+                      // DB接続先（MySQL/PostgreSQL）: ホスト:ポート / DB名を表示
+                      <>
+                        <span className="db-connection-item__separator" aria-hidden="true">
+                          /
+                        </span>
+                        <span className="db-connection-item__host">
+                          {conn.host}:{conn.port}
+                        </span>
+                        <span className="db-connection-item__separator" aria-hidden="true">
+                          /
+                        </span>
+                        <span className="db-connection-item__db-name">{conn.databaseName}</span>
+                      </>
+                    )}
                   </div>
                 </div>
 

--- a/output_system/frontend/src/services/api.ts
+++ b/output_system/frontend/src/services/api.ts
@@ -71,16 +71,20 @@ export async function getConnections(): Promise<DbConnection[]> {
  * POST /api/connections
  * 同じ接続名が既に存在する場合は 409 Conflict が返る。
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: endpointUrl を送信、port の変換はスキップ
+ * - dbType='mysql'/'postgresql' の場合: 従来通り port を数値に変換
+ *
  * @param input - 登録する接続先情報（パスワード含む）
  * @returns 登録されたDB接続先（パスワードなし）
  * @throws Error - バリデーションエラー（400）・接続名重複（409）・その他エラー
  */
 export async function createConnection(input: DbConnectionInput): Promise<DbConnection> {
-  // port は文字列で来た場合でも数値に変換してAPIへ送信する
-  const body: DbConnectionInput = {
-    ...input,
-    port: Number(input.port),
-  }
+  // GraphQL接続の場合はport変換をスキップ
+  const body: DbConnectionInput =
+    input.dbType === 'graphql'
+      ? { ...input }
+      : { ...input, port: Number(input.port) }
 
   const response = await fetch(buildApiUrl('/api/connections'), {
     method: 'POST',
@@ -102,6 +106,10 @@ export async function createConnection(input: DbConnectionInput): Promise<DbConn
  *
  * PUT /api/connections/:id
  *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql' の場合: endpointUrl を送信、port の変換はスキップ
+ * - dbType='mysql'/'postgresql' の場合: 従来通り port を数値に変換
+ *
  * @param id    - 更新する接続先のID
  * @param input - 更新内容（パスワード含む）
  * @returns 更新されたDB接続先（パスワードなし）
@@ -111,11 +119,11 @@ export async function updateConnection(
   id: string,
   input: DbConnectionInput,
 ): Promise<DbConnection> {
-  // port は文字列で来た場合でも数値に変換してAPIへ送信する
-  const body: DbConnectionInput = {
-    ...input,
-    port: Number(input.port),
-  }
+  // GraphQL接続の場合はport変換をスキップ
+  const body: DbConnectionInput =
+    input.dbType === 'graphql'
+      ? { ...input }
+      : { ...input, port: Number(input.port) }
 
   const response = await fetch(buildApiUrl(`/api/connections/${id}`), {
     method: 'PUT',
@@ -156,11 +164,15 @@ export async function deleteConnection(id: string): Promise<void> {
 }
 
 /**
- * DB接続テストを実行する
+ * DB/GraphQL接続テストを実行する
  *
  * POST /api/connections/test
- * 入力した接続情報でDBへの接続を試行し、成功/失敗を返す。
+ * 入力した接続情報でDB/GraphQLエンドポイントへの接続を試行し、成功/失敗を返す。
  * 200 は接続成功、400 は接続失敗（エラーメッセージ付き）を示す。
+ *
+ * PBI #200: GraphQL対応
+ * - dbType='graphql': endpointUrl のみ送信（port の変換はスキップ）
+ * - dbType='mysql'/'postgresql': 従来通り port を数値に変換
  *
  * @param input - テストする接続情報（パスワード含む）
  * @returns 接続テスト結果（success: boolean, message: string）
@@ -169,11 +181,11 @@ export async function deleteConnection(id: string): Promise<void> {
 export async function testConnection(
   input: DbConnectionInput,
 ): Promise<DbConnectionTestResult> {
-  // port は文字列で来た場合でも数値に変換してAPIへ送信する
-  const body: DbConnectionInput = {
-    ...input,
-    port: Number(input.port),
-  }
+  // GraphQL接続の場合はport変換をスキップ
+  const body: DbConnectionInput =
+    input.dbType === 'graphql'
+      ? { ...input }
+      : { ...input, port: Number(input.port) }
 
   const response = await fetch(buildApiUrl('/api/connections/test'), {
     method: 'POST',

--- a/output_system/frontend/src/types/index.ts
+++ b/output_system/frontend/src/types/index.ts
@@ -123,27 +123,34 @@ export interface SseConversationData {
 }
 
 // ---------------------------------------------------------------------------
-// DB接続先関連型（PBI #148 追加）
+// DB接続先関連型（PBI #148 追加、PBI #200 GraphQL対応）
 // ---------------------------------------------------------------------------
 
 /**
  * DB種別
  * バックエンドの DbConnection.dbType に対応する。
+ * PBI #200: 'graphql' を追加
  */
-export type DbType = 'mysql' | 'postgresql'
+export type DbType = 'mysql' | 'postgresql' | 'graphql'
 
 /**
  * DB接続先（読み取り用）
  * GET /api/connections レスポンスの各要素に対応する。
  * パスワードは返却されない（セキュリティ要件）。
  *
+ * PBI #200: GraphQL対応
+ * - dbType に 'graphql' を追加
+ * - endpointUrl を追加（GraphQL時のみ）
+ * - host/port/username/databaseName はGraphQL時はnull
+ *
  * @property id           - 接続先の一意識別子（UUID）
  * @property name         - 接続名（例: "本番DB"）
- * @property dbType       - DB種別（mysql / postgresql）
- * @property host         - ホスト名またはIPアドレス
- * @property port         - ポート番号
- * @property username     - DBユーザー名
- * @property databaseName - データベース名
+ * @property dbType       - DB種別（mysql / postgresql / graphql）
+ * @property host         - ホスト名またはIPアドレス（GraphQL時はnull）
+ * @property port         - ポート番号（GraphQL時はnull）
+ * @property username     - DBユーザー名（GraphQL時はnull）
+ * @property databaseName - データベース名（GraphQL時はnull）
+ * @property endpointUrl  - GraphQLエンドポイントURL（DB時はnull）
  * @property isLastUsed   - 最後に使用した接続先かどうか
  * @property createdAt    - 作成日時（ISO 8601文字列）
  * @property updatedAt    - 更新日時（ISO 8601文字列）
@@ -152,10 +159,11 @@ export interface DbConnection {
   id: string
   name: string
   dbType: DbType
-  host: string
-  port: number
-  username: string
-  databaseName: string
+  host: string | null
+  port: number | null
+  username: string | null
+  databaseName: string | null
+  endpointUrl: string | null
   isLastUsed: boolean
   createdAt: string
   updatedAt: string
@@ -166,22 +174,29 @@ export interface DbConnection {
  * POST /api/connections / PUT /api/connections/:id のリクエストボディに対応する。
  * パスワードを含む（登録・更新時のみ送信）。
  *
+ * PBI #200: GraphQL対応
+ * - dbType に 'graphql' を追加
+ * - endpointUrl を追加（GraphQL時は必須、DB時は不要）
+ * - host/port/username/password/databaseName はGraphQL時は不要
+ *
  * @property name         - 接続名
- * @property dbType       - DB種別（mysql / postgresql）
- * @property host         - ホスト名またはIPアドレス
- * @property port         - ポート番号（文字列として入力されることもあるためunion型）
- * @property username     - DBユーザー名
- * @property password     - DBパスワード（平文。バックエンドで暗号化して保存）
- * @property databaseName - データベース名
+ * @property dbType       - DB種別（mysql / postgresql / graphql）
+ * @property host         - ホスト名またはIPアドレス（DB時必須、GraphQL時不要）
+ * @property port         - ポート番号（文字列として入力されることもあるためunion型）（DB時必須、GraphQL時不要）
+ * @property username     - DBユーザー名（DB時必須、GraphQL時不要）
+ * @property password     - DBパスワード（平文。バックエンドで暗号化して保存）（DB時必須、GraphQL時不要）
+ * @property databaseName - データベース名（DB時必須、GraphQL時不要）
+ * @property endpointUrl  - GraphQLエンドポイントURL（GraphQL時必須、DB時不要）
  */
 export interface DbConnectionInput {
   name: string
   dbType: DbType
-  host: string
-  port: number | string
-  username: string
-  password: string
-  databaseName: string
+  host?: string
+  port?: number | string
+  username?: string
+  password?: string
+  databaseName?: string
+  endpointUrl?: string
 }
 
 /**

--- a/output_system/test/unit/schema.test.ts
+++ b/output_system/test/unit/schema.test.ts
@@ -7,9 +7,14 @@
  *   - buildSchemaInfo(): 純粋関数のため直接テスト
  *   - invalidateSchemaCache(): キャッシュ無効化の動作確認
  *
+ * PBI #200 追加:
+ *   - GraphQL接続先のスキーマ取得テスト（Introspection Query）
+ *   - MySQL テストの修正（SET NAMES utf8mb4 が raw を1回余分に呼ぶ）
+ *
  * テスト方針:
  *   - connectionManager.getById() をモックして実際のDB接続を行わない
  *   - knex をモックして実際のSQLを実行しない
+ *   - GraphQL Introspection は globalThis.fetch をモックして実際のHTTPリクエストを行わない
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -51,15 +56,18 @@ import Knex from 'knex'
 
 /**
  * DB接続先モックオブジェクトを生成するヘルパー
+ *
+ * PBI #200: GraphQL接続先にも対応（dbType='graphql', endpointUrl を追加）
  */
 function createMockConnection(overrides: Partial<{
   id: string
-  dbType: 'mysql' | 'postgresql'
-  host: string
-  port: number
-  username: string
+  dbType: 'mysql' | 'postgresql' | 'graphql'
+  host: string | null
+  port: number | null
+  username: string | null
   password: string
-  databaseName: string
+  databaseName: string | null
+  endpointUrl: string | null
 }> = {}) {
   return {
     id: 'test-connection-id',
@@ -70,6 +78,7 @@ function createMockConnection(overrides: Partial<{
     username: 'testuser',
     password: 'testpass',
     databaseName: 'testdb',
+    endpointUrl: null,
     isLastUsed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
@@ -243,7 +252,10 @@ describe('fetchSchema', () => {
     ]
 
     // MySQL の knex.raw は [rows, fields] のタプルを返す
-    const mockRaw = vi.fn().mockResolvedValue([mockRows, []])
+    // SET NAMES utf8mb4 も raw を呼ぶため、最初の呼び出しは undefined を返すモック
+    const mockRaw = vi.fn()
+      .mockResolvedValueOnce(undefined) // SET NAMES utf8mb4
+      .mockResolvedValueOnce([mockRows, []]) // INFORMATION_SCHEMA クエリ
     vi.mocked(Knex as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       raw: mockRaw,
       destroy: vi.fn().mockResolvedValue(undefined),
@@ -257,9 +269,12 @@ describe('fetchSchema', () => {
     expect(result.tables[0].columns[0]).toEqual({ name: 'customer_id', type: 'int', nullable: false, comment: null })
     expect(result.tables[0].columns[1]).toEqual({ name: 'first_name', type: 'varchar', nullable: true, comment: null })
 
-    // DATABASE() を含むSQLが実行されていること
-    expect(mockRaw).toHaveBeenCalledOnce()
-    const sqlArg: string = mockRaw.mock.calls[0][0]
+    // raw が2回呼ばれること（1回目: SET NAMES utf8mb4, 2回目: INFORMATION_SCHEMA クエリ）
+    expect(mockRaw).toHaveBeenCalledTimes(2)
+    // 1回目: SET NAMES utf8mb4
+    expect(mockRaw.mock.calls[0][0]).toBe('SET NAMES utf8mb4')
+    // 2回目: INFORMATION_SCHEMA クエリ（DATABASE() を含む）
+    const sqlArg: string = mockRaw.mock.calls[1][0]
     expect(sqlArg).toContain('DATABASE()')
     expect(sqlArg).toContain('information_schema.COLUMNS')
   })
@@ -354,5 +369,172 @@ describe('invalidateSchemaCache', () => {
     // 2回目のfetchSchema（キャッシュが無効化されているのでDBから再取得）
     await fetchSchema('test-connection-id')
     expect(mockRaw).toHaveBeenCalledTimes(2)
+  })
+})
+
+// -------------------------------------------------------------------
+// GraphQL Introspection スキーマ取得のユニットテスト（PBI #200 追加）
+// -------------------------------------------------------------------
+
+/**
+ * 【モジュール】fetchSchema（GraphQL向け）
+ * GraphQL接続先のスキーマ取得（Introspection Query）のテスト
+ *
+ * globalThis.fetch をモックして実際のHTTPリクエストを行わない。
+ */
+describe('fetchSchema (GraphQL)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAllSchemaCache()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * 【テスト対象】fetchSchema（GraphQL向け）
+   * 【テスト内容】dbType='graphql' のとき、Introspection Query が実行され SchemaInfo が返ること
+   * 【期待結果】OBJECT型のフィールドが tables として返り、ビルトイン型（__で始まる）は除外されること
+   */
+  it('should fetch GraphQL schema via Introspection Query', async () => {
+    // GraphQL接続先のモック設定
+    const mockConnection = createMockConnection({
+      dbType: 'graphql',
+      host: null,
+      port: null,
+      username: null,
+      databaseName: null,
+      endpointUrl: 'https://api.example.com/graphql',
+    })
+    vi.mocked(getById).mockReturnValue(mockConnection as any)
+
+    // Introspection レスポンスのモック
+    const mockIntrospectionResponse = {
+      data: {
+        __schema: {
+          types: [
+            {
+              name: 'User',
+              kind: 'OBJECT',
+              fields: [
+                {
+                  name: 'id',
+                  type: { name: null, kind: 'NON_NULL', ofType: { name: 'ID', kind: 'SCALAR' } },
+                },
+                {
+                  name: 'name',
+                  type: { name: 'String', kind: 'SCALAR', ofType: null },
+                },
+              ],
+            },
+            {
+              name: 'Query',
+              kind: 'OBJECT',
+              fields: [
+                {
+                  name: 'users',
+                  type: { name: null, kind: 'LIST', ofType: { name: 'User', kind: 'OBJECT' } },
+                },
+              ],
+            },
+            // ビルトイン型（除外されること）
+            {
+              name: '__Schema',
+              kind: 'OBJECT',
+              fields: [],
+            },
+            // SCALAR型（除外されること）
+            {
+              name: 'String',
+              kind: 'SCALAR',
+              fields: null,
+            },
+          ],
+        },
+      },
+    }
+
+    // fetch をモック
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockIntrospectionResponse,
+    } as Response)
+
+    const result: SchemaInfo = await fetchSchema('test-graphql-connection-id')
+
+    // GraphQL接続先のスキーマが正しく取得されること
+    expect(result.dbType).toBe('graphql')
+    expect(result.database).toBe('https://api.example.com/graphql')
+
+    // OBJECT型のみが返り、ビルトイン型とSCALAR型は除外されること
+    expect(result.tables).toHaveLength(2) // User と Query のみ
+    const userType = result.tables.find((t) => t.name === 'User')
+    expect(userType).toBeDefined()
+    expect(userType?.columns).toHaveLength(2)
+    // id フィールドは NON_NULL(ID) → 'ID!'
+    expect(userType?.columns[0]).toEqual({ name: 'id', type: 'ID!', nullable: false, comment: null })
+    // name フィールドは String（nullable）
+    expect(userType?.columns[1]).toEqual({ name: 'name', type: 'String', nullable: true, comment: null })
+
+    // ビルトイン型（__Schema）が除外されていること
+    const builtinType = result.tables.find((t) => t.name === '__Schema')
+    expect(builtinType).toBeUndefined()
+
+    // SCALAR型（String）が除外されていること
+    const scalarType = result.tables.find((t) => t.name === 'String')
+    expect(scalarType).toBeUndefined()
+  })
+
+  /**
+   * 【テスト対象】fetchSchema（GraphQL向け）
+   * 【テスト内容】HTTPエラーが返った場合
+   * 【期待結果】エラーがスローされること
+   */
+  it('should throw error when HTTP response is not ok', async () => {
+    const mockConnection = createMockConnection({
+      dbType: 'graphql',
+      host: null,
+      port: null,
+      username: null,
+      databaseName: null,
+      endpointUrl: 'https://api.example.com/graphql',
+    })
+    vi.mocked(getById).mockReturnValue(mockConnection as any)
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ errors: [] }),
+    } as Response)
+
+    await expect(fetchSchema('test-graphql-connection-id')).rejects.toThrow('HTTP 403')
+  })
+
+  /**
+   * 【テスト対象】fetchSchema（GraphQL向け）
+   * 【テスト内容】GraphQL Introspection が無効になっている場合
+   * 【期待結果】エラーがスローされること
+   */
+  it('should throw error when Introspection returns GraphQL errors', async () => {
+    const mockConnection = createMockConnection({
+      dbType: 'graphql',
+      host: null,
+      port: null,
+      username: null,
+      databaseName: null,
+      endpointUrl: 'https://api.example.com/graphql',
+    })
+    vi.mocked(getById).mockReturnValue(mockConnection as any)
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        errors: [{ message: 'Introspection is not allowed' }],
+      }),
+    } as Response)
+
+    await expect(fetchSchema('test-graphql-connection-id')).rejects.toThrow('Introspection')
   })
 })


### PR DESCRIPTION
## 概要

PBI #200「GraphQL接続先を登録・管理できる」の実装。既存のMySQL/PostgreSQL接続と並んで、GraphQL APIエンドポイントを接続先として登録・管理できるようにする。

## 実装内容

### Task 5.1.1 (#202): DBスキーマ変更
- `db_connections` テーブルに `endpoint_url TEXT DEFAULT NULL` カラム追加
- `host`, `port`, `username`, `password_encrypted`, `database_name` を NULL 許容に変更
- `db_type` CHECK制約に `'graphql'` を追加
- マイグレーションガード実装（カラム未存在時のみ ALTER TABLE 実行）

### Task 5.1.2 (#203): GraphQL CRUD API
- `connectionManager.ts`: GraphQL接続の作成・更新・削除・取得を実装
  - GraphQL時はDB固有フィールド（host/port等）をNULLで保存
  - `testGraphQLConnection()`: Introspection Queryで疎通確認（5秒タイムアウト）
- `connections.ts`: バリデーション関数をGraphQL対応に完全刷新
  - GraphQL: `endpointUrl` 必須、HTTP/HTTPSのURL形式チェック
  - DB: 従来通りのhost/port/username/databaseName必須チェック

### Task 5.1.3 (#204): GraphQLスキーマ取得
- `schema.ts`: `fetchSchemaGraphQL()` 関数追加
  - Introspection Queryでスキーマ取得
  - OBJECT/INTERFACE/INPUT_OBJECT型をフィルタリング（`__`プレフィックスの組み込み型除外）
  - `SchemaInfo` 形式に変換してキャッシュ・永続化
- `llm.ts`: `dbType` に `'graphql'` 追加、GraphQL用システムプロンプト実装
- ユニットテスト3件追加（正常系・HTTPエラー・Introspectionエラー）

### Task 5.1.4 (#205): フロントエンドフォーム切替
- `DbConnectionForm.tsx`: dbType選択に応じてフォームフィールドを動的切替
  - GraphQL選択時: endpointUrl入力欄のみ表示
  - MySQL/PostgreSQL選択時: 従来のhost/port/username/password/databaseName表示
- `DbConnectionList.tsx`: GraphQL接続先の表示形式（「GraphQL / エンドポイントURL」）
- `types/index.ts`: フロント/バック両方でnullable型対応

## テスト結果

- ユニットテスト: 224/225 passed（1件は本PBI無関係の既存失敗）
- 動作確認: GraphQL接続の作成・一覧表示・削除をAPIで確認
- TypeScriptコンパイル: backend/frontend共にエラーなし

Closes #200