### PR TITLE
[GraphQL自然言語クエリ・可視化] 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -155,3 +155,5 @@ npx playwright test test/e2e/app.spec.ts
 - PBI #150: SQL実行結果をグラフ・テーブルで切り替え表示できる（ChartRenderer/BarChart/LineChart/PieChart/DataTable/chartUtils.ts実装済み確認。既存コンポーネントが正しく機能することを動作確認。160件ユニットテスト全通過）
 - PBI #151: DB切替時にサイドバー会話履歴がDB別フィルタリングされる（historyDb.tsにlistConversationsByDbConnectionId追加、GET /api/historyのdbConnectionId必須化、useHistory dbConnectionId引数対応・DB切替時自動リフレッシュ、HistoryItemにcreatedAt表示追加、App.tsxにDB切替時チャットクリア追加。384件ユニットテスト全通過）
 - PBI #152: DB接続先未登録時に初回起動ガイドが表示される（WelcomeGuide.tsx新規作成、App.tsxにconnections.length===0の条件分岐追加、global.cssにウェルカム画面スタイル追加）
+- PBI #200: GraphQL接続先のCRUD・Introspectionスキーマ取得が動作する（db_connectionsにGraphQL対応カラム追加、schema.tsにGraphQL Introspection対応、フロントエンドの型定義にgraphql追加、DbManagementModalのGraphQLフォーム切替実装）
+- PBI #201: GraphQL APIに自然言語で問い合わせてデータを可視化できる（graphqlValidator.ts・graphqlExecutor.ts新規作成、chat.ts dbType分岐、llm.ts GraphQLシステムプロンプト強化、SQLDisplay labelプロパティ追加、ChatMessage/ChatContainer/App.tsx dbType伝播）

--- a/output_system/backend/src/routes/chat.ts
+++ b/output_system/backend/src/routes/chat.ts
@@ -3,19 +3,27 @@
  *
  * 自然言語の質問を受け取り、以下の処理を順次行いSSEで結果をストリーミングする:
  *   1. dbConnectionId から DBスキーマ取得（services/schema.ts / キャッシュ優先）
- *   2. Claude API でSQL・グラフ種別を生成（services/llm.ts）
- *   3. SQLバリデーション（services/sqlValidator.ts 経由 / database.executeQuery 内）
- *   4. SQL実行（services/database.ts / 指定DB接続先）
+ *   2. Claude API でクエリ（SQL or GraphQL）・グラフ種別を生成（services/llm.ts）
+ *   3. クエリバリデーション
+ *      - DB 接続の場合: sqlValidator（executeQuery 内の二重防御）
+ *      - GraphQL 接続の場合: graphqlValidator（Mutation/Subscription を拒否）
+ *   4. クエリ実行
+ *      - DB 接続の場合: services/database.ts（指定DB接続先で SQL 実行）
+ *      - GraphQL 接続の場合: services/graphqlExecutor.ts（fetch API で GraphQL 実行）
  *   5. 結果を SSE イベントとして送信
  *
  * PBI #149 改修:
  *   - リクエストボディから dbConnectionId を受け取り、スキーマ取得・クエリ実行に渡す
  *   - dbConnectionId が未指定の場合は 400 エラーを返す
  *
+ * PBI #201 追加:
+ *   - schema.dbType が 'graphql' の場合、SQL 実行パスの代わりに GraphQL 実行パスを使用
+ *   - GraphQL エラー（errors 配列・タイムアウト等）に対応したエラーハンドリングを追加
+ *
  * SSEイベント仕様（api.md参照）:
  *   event: conversation - 会話ID通知（新規会話作成時）
  *   event: message  - LLMが生成したテキストチャンク（逐次送信）
- *   event: sql      - 抽出したSQL文
+ *   event: sql      - 抽出したSQL/GraphQLクエリ文
  *   event: chart_type - 推奨グラフ種別（bar/line/pie/table）
  *   event: result   - クエリ実行結果（QueryResult形式）
  *   event: analysis - AI分析コメントチャンク（逐次送信）
@@ -25,6 +33,7 @@
  * セキュリティ:
  *   - LLMが生成したSQLは sqlValidator（executeQuery内の二重防御）で検証される
  *   - SELECT 以外のSQL（INSERT/DROP等）は event: error で拒否される
+ *   - LLMが生成したGraphQLクエリは graphqlValidator で検証される（Mutation/Subscription拒否）
  *   - エラーメッセージはユーザー向けと内部ログを分離し、内部情報（DBホスト等）の漏洩を防ぐ
  */
 
@@ -34,6 +43,13 @@ import { v4 as uuidv4, validate as uuidValidate } from 'uuid'
 import { fetchSchema, ConnectionNotFoundError as SchemaConnectionNotFoundError } from '../services/schema'
 import { LlmService, LlmConfigError, LlmApiError, LlmTimeoutError, LlmParseError, ConversationMessage } from '../services/llm'
 import { executeQuery, SqlValidationError } from '../services/database'
+import {
+  executeGraphQLQuery,
+  GraphQLValidationError,
+  GraphQLApiError,
+  GraphQLTimeoutError,
+  GraphQLConnectionError,
+} from '../services/graphqlExecutor'
 import {
   getHistoryDb,
   createConversation,
@@ -382,71 +398,171 @@ router.post('/', chatRateLimiter, async (req: Request, res: Response): Promise<v
     }
 
     // -----------------------------------------------------------------------
-    // Step 4: SQL バリデーション + クエリ実行（指定DB接続先で実行）
+    // Step 4: クエリバリデーション + 実行
+    // dbType に応じて SQL 実行パスと GraphQL 実行パスを切り替える
     // -----------------------------------------------------------------------
     if (!extractedSql) {
-      // SQL が生成されなかった場合: LLMのテキスト応答のみで正常終了する。
+      // クエリが生成されなかった場合: LLMのテキスト応答のみで正常終了する。
       // 質問が曖昧な場合やスキーマに該当テーブルがない場合にLLMがテキストで回答することを許容する。
       _saveAssistantMessage(activeConversationId, fullAssistantText || '', null, null, null, null)
       return
     }
 
-    try {
-      // executeQuery() 内で sqlValidator が呼ばれる（二重防御）
-      // SELECT 以外のSQL は SqlValidationError をスロー
-      // PBI #149: dbConnectionId を渡して指定DB接続先でクエリを実行
-      const queryResult = await executeQuery(dbConnectionId, extractedSql)
-
-      // クエリ結果を送信
-      sendSseEvent(res, 'result', {
-        columns: queryResult.columns,
-        rows: queryResult.rows,
-        chartType: extractedChartType,
-      })
-
+    if (schema.dbType === 'graphql') {
       // -----------------------------------------------------------------------
-      // Step 5: クエリ結果の分析コメント生成（ストリーミング）
+      // Step 4-GraphQL: GraphQL クエリバリデーション + 実行
+      // PBI #201: GraphQL 接続の場合は graphqlExecutor を使用
       // -----------------------------------------------------------------------
-      let analysisText = ''
       try {
-        const analysisGenerator = llmService.analyzeResults({
-          question: message.trim(),
-          sql: extractedSql,
+        // executeGraphQLQuery() 内で graphqlValidator が呼ばれる（二重防御）
+        // Mutation/Subscription は GraphQLValidationError をスロー
+        const queryResult = await executeGraphQLQuery(
+          // schema.database には GraphQL の場合エンドポイント URL が格納されている
+          schema.database,
+          extractedSql
+        )
+
+        // クエリ結果を送信
+        sendSseEvent(res, 'result', {
           columns: queryResult.columns,
           rows: queryResult.rows,
+          chartType: extractedChartType,
         })
 
-        for await (const chunk of analysisGenerator) {
-          analysisText += chunk
-          sendSseEvent(res, 'analysis', { chunk })
+        // -----------------------------------------------------------------------
+        // Step 5-GraphQL: GraphQL結果の分析コメント生成（ストリーミング）
+        // -----------------------------------------------------------------------
+        let analysisText = ''
+        try {
+          const analysisGenerator = llmService.analyzeResults({
+            question: message.trim(),
+            sql: extractedSql,
+            columns: queryResult.columns,
+            rows: queryResult.rows,
+            dbType: 'graphql',
+          })
+
+          for await (const chunk of analysisGenerator) {
+            analysisText += chunk
+            sendSseEvent(res, 'analysis', { chunk })
+          }
+        } catch (err) {
+          // 分析コメント生成失敗はログに記録するが、メインフローは止めない
+          console.error('[chat] analyzeResults (GraphQL) error:', err)
         }
+
+        // assistant メッセージをDB に保存（sql=GraphQLクエリ, chart_type, query_result, analysis 含む）
+        _saveAssistantMessage(
+          activeConversationId,
+          fullAssistantText,
+          extractedSql,
+          extractedChartType,
+          queryResult,
+          null,
+          analysisText || null
+        )
       } catch (err) {
-        // 分析コメント生成失敗はログに記録するが、メインフローは止めない
-        console.error('[chat] analyzeResults error:', err)
+        // GraphQL バリデーション失敗または実行エラー
+        // 内部エラー詳細はサーバーログに記録
+        console.error('[chat] executeGraphQLQuery error:', err)
+
+        // エラーの種類に応じたガイドメッセージを生成する（Task 5.2.3）
+        let userMessage: string
+        if (err instanceof GraphQLValidationError) {
+          // Mutation/Subscription バリデーションエラー
+          userMessage = err.message
+        } else if (err instanceof GraphQLTimeoutError) {
+          // タイムアウトエラー
+          userMessage = '応答に時間がかかりすぎました。より単純な質問を試してください。'
+        } else if (err instanceof GraphQLApiError) {
+          // GraphQL エラーレスポンス（errors 配列）
+          const firstError = err.errors[0]
+          if (firstError?.message.toLowerCase().includes('syntax') ||
+              firstError?.message.toLowerCase().includes('parse')) {
+            // 構文エラー
+            userMessage = 'クエリの生成に失敗しました。質問を変えてみてください。'
+          } else if (firstError?.message.toLowerCase().includes('field') ||
+                     firstError?.message.toLowerCase().includes('cannot query')) {
+            // フィールドエラー
+            userMessage = '指定されたフィールドが見つかりません。別の質問を試してください。'
+          } else {
+            // その他の GraphQL エラー
+            userMessage = `エラーが発生しました。質問を変えてみてください。`
+          }
+        } else if (err instanceof GraphQLConnectionError) {
+          // 接続エラー（HTTP エラー含む）
+          userMessage = 'GraphQL APIに接続できません。エンドポイントURLを確認してください。'
+        } else {
+          // 予期しないエラー
+          userMessage = 'GraphQLクエリの実行中にエラーが発生しました。質問を変えてみてください。'
+        }
+
+        sendSseEvent(res, 'error', { message: userMessage })
+        _saveAssistantMessage(activeConversationId, fullAssistantText || userMessage, extractedSql, extractedChartType, null, userMessage)
       }
+    } else {
+      // -----------------------------------------------------------------------
+      // Step 4-SQL: SQL バリデーション + クエリ実行（指定DB接続先で実行）
+      // 既存の SQL 実行パス（DB 接続の場合）
+      // -----------------------------------------------------------------------
+      try {
+        // executeQuery() 内で sqlValidator が呼ばれる（二重防御）
+        // SELECT 以外のSQL は SqlValidationError をスロー
+        // PBI #149: dbConnectionId を渡して指定DB接続先でクエリを実行
+        const queryResult = await executeQuery(dbConnectionId, extractedSql)
 
-      // assistant メッセージをDB に保存（sql, chart_type, query_result, analysis 含む）
-      _saveAssistantMessage(
-        activeConversationId,
-        fullAssistantText,
-        extractedSql,
-        extractedChartType,
-        queryResult,
-        null,
-        analysisText || null
-      )
-    } catch (err) {
-      // SQL バリデーション失敗または実行エラー
-      // 内部エラー詳細（DBホスト名等）はサーバーログに記録
-      console.error('[chat] executeQuery error:', err)
+        // クエリ結果を送信
+        sendSseEvent(res, 'result', {
+          columns: queryResult.columns,
+          rows: queryResult.rows,
+          chartType: extractedChartType,
+        })
 
-      const userMessage =
-        err instanceof SqlValidationError
-          ? `SQL バリデーションエラー: ${err.message}`
-          : 'SQL の実行中にエラーが発生しました。'
+        // -----------------------------------------------------------------------
+        // Step 5-SQL: クエリ結果の分析コメント生成（ストリーミング）
+        // -----------------------------------------------------------------------
+        let analysisText = ''
+        try {
+          const analysisGenerator = llmService.analyzeResults({
+            question: message.trim(),
+            sql: extractedSql,
+            columns: queryResult.columns,
+            rows: queryResult.rows,
+            dbType: schema.dbType,
+          })
 
-      sendSseEvent(res, 'error', { message: userMessage })
-      _saveAssistantMessage(activeConversationId, fullAssistantText || userMessage, extractedSql, extractedChartType, null, userMessage)
+          for await (const chunk of analysisGenerator) {
+            analysisText += chunk
+            sendSseEvent(res, 'analysis', { chunk })
+          }
+        } catch (err) {
+          // 分析コメント生成失敗はログに記録するが、メインフローは止めない
+          console.error('[chat] analyzeResults error:', err)
+        }
+
+        // assistant メッセージをDB に保存（sql, chart_type, query_result, analysis 含む）
+        _saveAssistantMessage(
+          activeConversationId,
+          fullAssistantText,
+          extractedSql,
+          extractedChartType,
+          queryResult,
+          null,
+          analysisText || null
+        )
+      } catch (err) {
+        // SQL バリデーション失敗または実行エラー
+        // 内部エラー詳細（DBホスト名等）はサーバーログに記録
+        console.error('[chat] executeQuery error:', err)
+
+        const userMessage =
+          err instanceof SqlValidationError
+            ? `SQL バリデーションエラー: ${err.message}`
+            : 'SQL の実行中にエラーが発生しました。'
+
+        sendSseEvent(res, 'error', { message: userMessage })
+        _saveAssistantMessage(activeConversationId, fullAssistantText || userMessage, extractedSql, extractedChartType, null, userMessage)
+      }
     }
   } catch (err) {
     // 予期しないエラー（上記の try-catch を抜けてきた場合）

--- a/output_system/backend/src/services/graphqlExecutor.ts
+++ b/output_system/backend/src/services/graphqlExecutor.ts
@@ -1,0 +1,361 @@
+/**
+ * GraphQLクエリ実行サービス
+ *
+ * Node.js 標準の fetch API を使用して GraphQL エンドポイントにクエリを送信し、
+ * レスポンスを DB 接続と同じ QueryResult 形式（rows/columns）に変換して返す。
+ *
+ * 主な責務:
+ *   - GraphQL エンドポイントへの POST リクエスト送信
+ *   - レスポンスの data 部分を rows/columns 形式に整形
+ *   - ネストしたオブジェクトのフラット化（例: { user: { name: "Alice" } } → { "user.name": "Alice" }）
+ *   - エラーレスポンス（errors 配列）の検出と変換
+ *   - タイムアウト制御（AbortController）
+ *
+ * 参考:
+ *   - GraphQL over HTTP: https://graphql.github.io/graphql-over-http/
+ *   - GraphQL Errors: https://spec.graphql.org/October2021/#sec-Errors
+ */
+
+import { validateGraphQL } from './graphqlValidator'
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/**
+ * クエリ実行結果（DB 接続と同じ形式）
+ */
+export interface QueryResult {
+  /** 列名一覧 */
+  columns: string[]
+  /** データ行（キー: カラム名、値: 任意の型） */
+  rows: Record<string, unknown>[]
+}
+
+/**
+ * GraphQL レスポンスのエラーオブジェクト
+ * @see https://spec.graphql.org/October2021/#sec-Errors
+ */
+export interface GraphQLError {
+  message: string
+  locations?: Array<{ line: number; column: number }>
+  path?: Array<string | number>
+  extensions?: Record<string, unknown>
+}
+
+/**
+ * GraphQL レスポンスボディの型
+ * data と errors の両方が存在する場合（部分成功）がある。
+ */
+interface GraphQLResponseBody {
+  data?: Record<string, unknown> | null
+  errors?: GraphQLError[]
+}
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/**
+ * GraphQL リクエストのタイムアウト（ミリ秒）
+ * 大きなクエリでも応答できるよう 30 秒に設定する。
+ */
+const GRAPHQL_REQUEST_TIMEOUT_MS = 30_000
+
+// =============================================================================
+// ユーティリティ関数
+// =============================================================================
+
+/**
+ * ネストしたオブジェクトをフラット化する（再帰的）
+ *
+ * GraphQL レスポンスにネストしたオブジェクトが含まれる場合、
+ * ドット記法のキー名に展開してフラットなオブジェクトにする。
+ *
+ * DB 接続と同じ rows/columns 形式で可視化するために必要。
+ *
+ * @param obj - フラット化対象のオブジェクト
+ * @param prefix - 再帰呼び出し時のキープレフィックス（外部から指定不要）
+ * @returns フラット化されたオブジェクト
+ *
+ * @example
+ * ```typescript
+ * flattenObject({ user: { name: 'Alice', age: 30 }, active: true })
+ * // => { 'user.name': 'Alice', 'user.age': 30, 'active': true }
+ *
+ * flattenObject({ items: [{ id: 1 }, { id: 2 }] })
+ * // => { 'items': [{ id: 1 }, { id: 2 }] }  // 配列はそのまま保持
+ * ```
+ */
+export function flattenObject(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      // ネストしたオブジェクト: 再帰的にフラット化
+      const nested = flattenObject(value as Record<string, unknown>, fullKey)
+      Object.assign(result, nested)
+    } else {
+      // スカラー値・配列・null: そのまま設定
+      result[fullKey] = value
+    }
+  }
+
+  return result
+}
+
+/**
+ * GraphQL レスポンスの data 部分を rows/columns 形式に変換する
+ *
+ * data オブジェクトの最初のキーの値が結果配列と想定する（キー名は動的）。
+ * 各行のネストしたオブジェクトはフラット化する。
+ * 結果が配列でない場合は1行として扱う。
+ *
+ * @param data - GraphQL レスポンスの data フィールド
+ * @returns { columns, rows } 形式の結果
+ *
+ * @example
+ * ```typescript
+ * // 配列の場合
+ * formatGraphQLResult({ users: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] })
+ * // => { columns: ['id', 'name'], rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+ *
+ * // 単一オブジェクトの場合
+ * formatGraphQLResult({ user: { id: 1, name: 'Alice' } })
+ * // => { columns: ['id', 'name'], rows: [{ id: 1, name: 'Alice' }] }
+ * ```
+ */
+export function formatGraphQLResult(data: Record<string, unknown>): QueryResult {
+  // data が空の場合
+  const keys = Object.keys(data)
+  if (keys.length === 0) {
+    return { columns: [], rows: [] }
+  }
+
+  // data の最初のキーの値を結果として取得
+  // GraphQL レスポンスは通常 { queryName: [...] } の形式
+  const firstKey = keys[0]
+  const firstValue = data[firstKey]
+
+  let rawRows: Record<string, unknown>[]
+
+  if (Array.isArray(firstValue)) {
+    // 通常の配列結果
+    rawRows = firstValue.map((item) => {
+      if (item !== null && typeof item === 'object' && !Array.isArray(item)) {
+        return item as Record<string, unknown>
+      }
+      // プリミティブ値の配列の場合は値をキーとしてラップ
+      return { [firstKey]: item }
+    })
+  } else if (firstValue !== null && typeof firstValue === 'object' && !Array.isArray(firstValue)) {
+    // 単一オブジェクトの場合は1行として扱う
+    rawRows = [firstValue as Record<string, unknown>]
+  } else {
+    // プリミティブ値（数値・文字列等）の場合
+    rawRows = [{ [firstKey]: firstValue }]
+  }
+
+  if (rawRows.length === 0) {
+    return { columns: [], rows: [] }
+  }
+
+  // 各行をフラット化する（ネストしたオブジェクトを展開）
+  const flatRows = rawRows.map((row) => flattenObject(row))
+
+  // 全行からカラム名を収集（最初の行を基準とし、他の行に存在するカラムも追加）
+  const columnSet = new Set<string>()
+  for (const row of flatRows) {
+    for (const key of Object.keys(row)) {
+      columnSet.add(key)
+    }
+  }
+  const columns = Array.from(columnSet)
+
+  return { columns, rows: flatRows }
+}
+
+// =============================================================================
+// GraphQL バリデーションエラークラス
+// =============================================================================
+
+/**
+ * GraphQL クエリバリデーションエラー
+ *
+ * Mutation / Subscription / 空クエリ等のバリデーション失敗時にスローされる。
+ * 上位ルーターでは ユーザー向けメッセージを SSE error イベントで送信することを推奨。
+ */
+export class GraphQLValidationError extends Error {
+  readonly type = 'GraphQLValidationError' as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'GraphQLValidationError'
+    Object.setPrototypeOf(this, GraphQLValidationError.prototype)
+  }
+}
+
+/**
+ * GraphQL API 実行エラー（エラーレスポンスが返った場合）
+ *
+ * GraphQL レスポンスの errors 配列が存在する場合にスローされる。
+ * errors フィールドに元のエラーオブジェクト配列を保持する。
+ */
+export class GraphQLApiError extends Error {
+  readonly type = 'GraphQLApiError' as const
+  readonly errors: GraphQLError[]
+
+  constructor(message: string, errors: GraphQLError[]) {
+    super(message)
+    this.name = 'GraphQLApiError'
+    this.errors = errors
+    Object.setPrototypeOf(this, GraphQLApiError.prototype)
+  }
+}
+
+/**
+ * GraphQL タイムアウトエラー
+ *
+ * fetch のタイムアウト（AbortController）が発動した場合にスローされる。
+ */
+export class GraphQLTimeoutError extends Error {
+  readonly type = 'GraphQLTimeoutError' as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'GraphQLTimeoutError'
+    Object.setPrototypeOf(this, GraphQLTimeoutError.prototype)
+  }
+}
+
+/**
+ * GraphQL 接続エラー（HTTP エラー等）
+ *
+ * エンドポイントへの接続失敗、HTTP ステータスエラー等の場合にスローされる。
+ */
+export class GraphQLConnectionError extends Error {
+  readonly type = 'GraphQLConnectionError' as const
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'GraphQLConnectionError'
+    Object.setPrototypeOf(this, GraphQLConnectionError.prototype)
+  }
+}
+
+// =============================================================================
+// GraphQL クエリ実行
+// =============================================================================
+
+/**
+ * GraphQL クエリをエンドポイントに送信して実行し、結果を返す
+ *
+ * 処理フロー:
+ *   1. クエリバリデーション（Mutation/Subscription/空クエリを拒否）
+ *   2. fetch API で GraphQL エンドポイントに POST
+ *   3. HTTP エラーチェック
+ *   4. GraphQL エラーレスポンス（errors 配列）の検出
+ *   5. data 部分を rows/columns 形式に変換して返す
+ *
+ * 部分成功（data と errors の両方が存在）の場合は data を結果として返す。
+ *
+ * @param endpointUrl - GraphQL エンドポイント URL
+ * @param query - GraphQL クエリ文字列（Query オペレーションのみ許可）
+ * @returns QueryResult - { columns, rows } 形式の実行結果
+ * @throws GraphQLValidationError - クエリバリデーション失敗（Mutation 等）
+ * @throws GraphQLConnectionError - HTTP エラーまたは接続失敗
+ * @throws GraphQLApiError - GraphQL エラーレスポンス（errors 配列あり）
+ * @throws GraphQLTimeoutError - タイムアウト
+ */
+export async function executeGraphQLQuery(
+  endpointUrl: string,
+  query: string
+): Promise<QueryResult> {
+  // Step 1: クエリバリデーション
+  const validation = validateGraphQL(query)
+  if (!validation.ok) {
+    throw new GraphQLValidationError(
+      validation.reason ?? 'GraphQLクエリのバリデーションに失敗しました。'
+    )
+  }
+
+  // Step 2: fetch API で GraphQL エンドポイントに POST
+  // AbortController でタイムアウトを制御する
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), GRAPHQL_REQUEST_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(endpointUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({
+        // バリデーション済みのクエリを送信
+        query: validation.sanitizedQuery ?? query,
+        variables: {},
+      }),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    clearTimeout(timeoutId)
+    // AbortError はタイムアウトとして扱う
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new GraphQLTimeoutError(
+        `GraphQL APIへのリクエストがタイムアウトしました（${GRAPHQL_REQUEST_TIMEOUT_MS / 1000}秒）。より単純な質問を試してください。`
+      )
+    }
+    throw new GraphQLConnectionError(
+      `GraphQL APIへの接続に失敗しました: ${err instanceof Error ? err.message : String(err)}`
+    )
+  } finally {
+    clearTimeout(timeoutId)
+  }
+
+  // Step 3: HTTP エラーチェック
+  if (!response.ok) {
+    throw new GraphQLConnectionError(
+      `GraphQL APIがHTTPエラーを返しました: HTTP ${response.status} ${response.statusText}`
+    )
+  }
+
+  // Step 4: レスポンスボディを JSON パース
+  let body: GraphQLResponseBody
+  try {
+    body = await response.json() as GraphQLResponseBody
+  } catch (err) {
+    throw new GraphQLConnectionError(
+      `GraphQL APIのレスポンスが不正なJSON形式です: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+
+  // Step 5: GraphQL エラーレスポンスの検出
+  // errors と data の両方が存在する場合（部分成功）は data を優先するが、
+  // data が null/undefined の場合は errors をエラーとして扱う
+  if (body.errors && body.errors.length > 0 && !body.data) {
+    throw new GraphQLApiError(
+      `GraphQL APIがエラーを返しました: ${body.errors[0].message}`,
+      body.errors
+    )
+  }
+
+  // Step 6: data 部分を rows/columns 形式に変換
+  const data = body.data ?? {}
+  if (Object.keys(data).length === 0) {
+    // data が空の場合（エラーなし・データなし）
+    return { columns: [], rows: [] }
+  }
+
+  return formatGraphQLResult(data)
+}

--- a/output_system/backend/src/services/graphqlValidator.ts
+++ b/output_system/backend/src/services/graphqlValidator.ts
@@ -1,0 +1,136 @@
+/**
+ * GraphQLクエリバリデーターサービス
+ *
+ * LLMが生成したGraphQLクエリを実行前にバリデーションし、
+ * Query オペレーションのみを許可する。
+ * Mutation / Subscription / 空クエリは拒否する。
+ *
+ * セキュリティ設計方針（二重防御）:
+ *   1. このバリデーター（第1層）: 実行前にキーワードレベルでチェック
+ *   2. graphqlExecutor（第2層）: 実行時にもレスポンスを検証
+ *
+ * 許可するオペレーション:
+ *   - query { ... }   (明示的な query キーワード)
+ *   - { ... }         (shorthand query、キーワードなし)
+ *
+ * 拒否するオペレーション:
+ *   - mutation { ... }
+ *   - subscription { ... }
+ *   - 空文字・空白のみ
+ *
+ * 参考:
+ *   - GraphQL仕様 (Operations): https://spec.graphql.org/October2021/#sec-Language.Operations
+ *   - OWASP API Security: https://owasp.org/www-project-api-security/
+ */
+
+/** バリデーション結果 */
+export interface GraphQLValidationResult {
+  /** true: 実行許可, false: 実行拒否 */
+  ok: boolean
+  /**
+   * ok が false のときに拒否理由を説明するメッセージ（ユーザー向け）。
+   * ok が true のときは undefined。
+   */
+  reason?: string
+  /**
+   * ok が true のとき、正規化済みのクエリ文字列。
+   * ok が false のときは undefined。
+   */
+  sanitizedQuery?: string
+}
+
+/**
+ * GraphQL クエリ文字列を前処理する（コメント除去・正規化）
+ *
+ * GraphQL のコメント形式:
+ *   - 行コメント: # から行末まで（SQL の -- に相当）
+ *
+ * @param query - 元の GraphQL クエリ文字列
+ * @returns コメント除去・正規化済みの文字列
+ */
+function preprocessQuery(query: string): string {
+  // 行コメント（#...）を除去
+  const withoutComments = query.replace(/#[^\r\n]*/g, ' ')
+  // 連続する空白・改行を正規化
+  return withoutComments.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * GraphQL クエリをバリデーションし、実行可否を返す
+ *
+ * 以下の順序でチェックを行う:
+ *   1. 空文字チェック
+ *   2. コメント除去・正規化
+ *   3. Mutation キーワード検出による拒否
+ *   4. Subscription キーワード検出による拒否
+ *   5. Query または shorthand query ({ で始まる) であることを確認
+ *
+ * @param query - バリデーション対象の GraphQL クエリ文字列
+ * @returns GraphQLValidationResult - ok: true なら実行可、false なら reason に拒否理由
+ *
+ * @example
+ * ```typescript
+ * // 許可されるケース
+ * validateGraphQL('{ users { id name } }')
+ * // => { ok: true, sanitizedQuery: '{ users { id name } }' }
+ *
+ * validateGraphQL('query GetUsers { users { id } }')
+ * // => { ok: true, sanitizedQuery: 'query GetUsers { users { id } }' }
+ *
+ * // 拒否されるケース
+ * validateGraphQL('mutation CreateUser { createUser(name: "Alice") { id } }')
+ * // => { ok: false, reason: '...' }
+ * ```
+ */
+export function validateGraphQL(query: string): GraphQLValidationResult {
+  // チェック 1: 空文字・空白のみ
+  if (!query || !query.trim()) {
+    return {
+      ok: false,
+      reason: 'GraphQLクエリが空です。',
+    }
+  }
+
+  // チェック 2: コメント除去・正規化
+  const normalized = preprocessQuery(query)
+  const upperQuery = normalized.toUpperCase()
+
+  // チェック 3: Mutation キーワードの検出
+  // 単語境界（\b）で囲んで識別子名への誤検知を防ぐ
+  // 例: "mutation" が含まれていても、"mutationResult" のようなフィールド名は許可しない
+  if (/\bmutation\b/i.test(normalized)) {
+    return {
+      ok: false,
+      reason: 'データの変更操作（mutation）はサポートされていません。データの取得に関する質問を入力してください。',
+    }
+  }
+
+  // チェック 4: Subscription キーワードの検出
+  if (/\bsubscription\b/i.test(normalized)) {
+    return {
+      ok: false,
+      reason: 'サブスクリプション操作（subscription）はサポートされていません。データの取得に関する質問を入力してください。',
+    }
+  }
+
+  // チェック 5: 有効な Query 形式で始まるか確認
+  // 許可形式:
+  //   - shorthand query: { ... }
+  //   - 名前付き query: query { ... } または query QueryName { ... }
+  //   - fragment 定義のみは拒否
+  const startsWithQuery = /^\s*(\{|query\b)/i.test(normalized)
+  if (!startsWithQuery) {
+    return {
+      ok: false,
+      reason: 'GraphQLクエリは { または query で始まる必要があります。データの取得クエリのみ許可されています。',
+    }
+  }
+
+  // すべてのチェックを通過: 実行許可
+  // upperQuery は使用しないが、将来のチェック拡張のため保持
+  void upperQuery
+  return {
+    ok: true,
+    sanitizedQuery: normalized,
+  }
+}

--- a/output_system/backend/src/services/llm.ts
+++ b/output_system/backend/src/services/llm.ts
@@ -131,8 +131,11 @@ const REQUEST_TIMEOUT_MS = 60_000
 /**
  * システムプロンプトを生成する
  *
- * DB種別に応じたSQL方言指示を含める。
- * スキーマに含まれるコメント情報の活用を明示的に指示する。
+ * DB種別に応じたSQL方言指示（DB接続）またはGraphQLクエリ生成指示を含める。
+ * GraphQL時:
+ *   - Query のみ生成。Mutation/Subscription は絶対に生成しない
+ *   - フラットなデータ構造を返すよう指示（可視化のため）
+ *   - JSON レスポンスフォーマットは SQL 時と同一（"sql" フィールドに GraphQL クエリを格納）
  *
  * @param dbType - DB種別（mysql / postgresql / graphql）
  * @returns システムプロンプト文字列
@@ -141,26 +144,49 @@ function buildSystemPrompt(dbType: 'mysql' | 'postgresql' | 'graphql'): string {
   if (dbType === 'graphql') {
     return `You are a helpful data analyst assistant. Your role is to help users understand and query GraphQL APIs.
 
-DATABASE TYPE: GraphQL
-The connected data source is a GraphQL API. You can help users understand the schema and formulate GraphQL queries.
+DATA SOURCE TYPE: GraphQL API
+The connected data source is a GraphQL API. Your task is to translate natural language questions into GraphQL queries for data visualization.
 
 SCHEMA INFORMATION:
 The user's message always contains a "Database Schema" section that lists ALL available types and fields. This is the complete and authoritative schema of the connected GraphQL API.
 - **NEVER say you don't have schema information. It is ALWAYS provided in the user's message.**
 - **NEVER ask the user to provide type or field information. You already have it.**
 - Use ONLY the types and fields listed in the "Database Schema" section.
+- If the "Database Schema" section shows no types, tell the user that the API has no accessible types and suggest checking the connection settings. Do NOT generate any query in this case.
 
-RULES:
-1. When the user asks about data, generate a GraphQL query to fetch it.
-2. Format GraphQL queries in the "sql" block (they will be labeled appropriately in the UI).
-3. Choose the most appropriate chart type for visualization:
-   - "bar"  : Category comparisons
-   - "line" : Time series data
-   - "pie"  : Proportional data
-   - "table": Complex data or when no specific chart is appropriate
+CRITICAL SECURITY RULES:
+1. **ONLY generate Query operations. NEVER generate Mutation or Subscription operations.**
+2. **Do NOT use "mutation" or "subscription" keywords under any circumstances.**
+3. If the user asks to create, update, or delete data, politely decline and explain that only data retrieval is supported.
 
-IMPORTANT: Always try your best to help the user. If the question is vague, make reasonable assumptions based on the available schema.
-`
+QUERY GENERATION RULES:
+4. Generate GraphQL queries that return FLAT data structures optimized for visualization:
+   - Prefer scalar fields (String, Int, Float, Boolean) over nested objects
+   - If you need nested fields, expand them to get scalar values directly
+   - Avoid deeply nested structures that are hard to tabulate
+   - Example: prefer \`{ user { name } }\` over \`{ user }\` when \`user\` is an object type
+5. Choose the most appropriate chart type for visualization:
+   - "bar"  : Category comparisons (rankings, counts by category)
+   - "line" : Time series data (trends over time)
+   - "pie"  : Proportional data (distribution, share percentages)
+   - "table": Complex data, many fields, or when no specific chart is appropriate
+6. **CRITICAL: NEVER reference types or fields that are not listed in the Database Schema.**
+
+IMPORTANT: Always try your best to help the user. If the question is vague, make reasonable assumptions based on the available schema and explain your interpretation.
+
+RESPONSE FORMAT:
+First, provide a brief explanation of your approach in the user's language.
+Then, include a JSON code block with EXACTLY this structure:
+
+\`\`\`json
+{
+  "sql": "query { ... }",
+  "chart_type": "table"
+}
+\`\`\`
+
+The "sql" field contains the GraphQL query (the field name "sql" is reused for compatibility).
+The JSON must always be at the end of your response.`
   }
 
   const dialectName = dbType === 'mysql' ? 'MySQL' : 'PostgreSQL'
@@ -214,15 +240,39 @@ The JSON must always be at the end of your response.`
  * SchemaInfo をシステムプロンプトに埋め込むテキスト形式に変換する
  *
  * LLM が理解しやすいよう、テーブル名とカラム情報を人間が読みやすい形式で出力する。
+ * GraphQL 接続の場合は、Type/Field として出力する（テーブル/カラムの代わり）。
  *
  * @param schema - fetchSchema() から取得したスキーマ情報
  * @returns プロンプトに埋め込む文字列
  *
- * @example
- * schemaToPromptText({ database: 'mydb', tables: [{ name: 'users', columns: [...] }] })
- * // => "Database: mydb\n\nTable: users\n  - id (integer, NOT NULL)\n  - name (text, NULL)..."
+ * @example DB の場合:
+ * schemaToPromptText({ dbType: 'mysql', database: 'mydb', tables: [...] })
+ * // => "Database: mydb (MySQL)\n\nTable: users\n  - id (integer, NOT NULL)\n..."
+ *
+ * @example GraphQL の場合:
+ * schemaToPromptText({ dbType: 'graphql', database: 'https://...', tables: [...] })
+ * // => "GraphQL API: https://...\n\nType: User\n  - id (ID!, required)\n..."
  */
 export function schemaToPromptText(schema: SchemaInfo): string {
+  if (schema.dbType === 'graphql') {
+    // GraphQL 接続の場合: Type/Field として出力
+    const lines: string[] = [`GraphQL API: ${schema.database}`, '']
+
+    for (const table of schema.tables) {
+      // table.name = GraphQL の Type 名
+      lines.push(`Type: ${table.name}`)
+      for (const col of table.columns) {
+        // col.nullable = false の場合は NON_NULL（required）
+        const nullability = col.nullable ? 'nullable' : 'required'
+        lines.push(`  - ${col.name}: ${col.type} (${nullability})`)
+      }
+      lines.push('')
+    }
+
+    return lines.join('\n').trimEnd()
+  }
+
+  // DB 接続の場合: Table/Column として出力（既存の処理）
   const dbTypeLabel = schema.dbType === 'mysql' ? 'MySQL' : 'PostgreSQL'
   const lines: string[] = [`Database: ${schema.database} (${dbTypeLabel})`, '']
 
@@ -475,10 +525,11 @@ export class LlmService {
   /**
    * クエリ結果をLLMに渡し、分析コメントをストリーミング生成する
    *
-   * SQL実行結果に対してデータの傾向・特徴・注目ポイントを解説する。
+   * SQL/GraphQLクエリ実行結果に対してデータの傾向・特徴・注目ポイントを解説する。
+   * dbType が 'graphql' の場合は「実行したSQL」の表示を「実行したGraphQLクエリ」に変える。
    * 呼び出し側は for-await-of で テキストチャンクを受け取る。
    *
-   * @param input - 元の質問、実行SQL、クエリ結果
+   * @param input - 元の質問、実行クエリ（SQL or GraphQL）、クエリ結果、DB種別
    * @yields string - テキストチャンク（逐次送信用）
    */
   async *analyzeResults(input: {
@@ -486,8 +537,9 @@ export class LlmService {
     sql: string
     columns: string[]
     rows: Record<string, unknown>[]
+    dbType?: 'mysql' | 'postgresql' | 'graphql'
   }): AsyncGenerator<string> {
-    const { question, sql, columns, rows } = input
+    const { question, sql, columns, rows, dbType } = input
 
     // 結果データをテキスト化（最大50行に制限してトークン節約）
     const displayRows = rows.slice(0, 50)
@@ -496,12 +548,15 @@ export class LlmService {
     ).join('\n')
     const truncatedNote = rows.length > 50 ? `\n（全${rows.length}件中、先頭50件を表示）` : ''
 
+    // GraphQL と SQL でクエリの表現を切り替える
+    const queryLabel = dbType === 'graphql' ? '実行したGraphQLクエリ' : '実行したSQL'
+
     const userMessage = `以下のデータについて、簡潔に分析コメントしてください。
 
 ## ユーザーの質問
 ${question}
 
-## 実行したSQL
+## ${queryLabel}
 ${sql}
 
 ## クエリ結果（${rows.length}件）

--- a/output_system/backend/vitest.config.ts
+++ b/output_system/backend/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       // Task 1.2.4: schema.ts, Task 2.1.1: sqlValidator.ts を含む
       // Task 2.2.1: llm.ts を追加
       // Task 4.1.1: historyDb.ts を追加
-      include: ['src/services/schema.ts', 'src/services/sqlValidator.ts', 'src/services/llm.ts', 'src/services/historyDb.ts', 'src/services/database.ts'],
+      include: ['src/services/schema.ts', 'src/services/sqlValidator.ts', 'src/services/llm.ts', 'src/services/historyDb.ts', 'src/services/database.ts', 'src/services/graphqlValidator.ts', 'src/services/graphqlExecutor.ts'],
       reporter: ['text', 'json', 'html'],
       // 80%以上のカバレッジを要求
       thresholds: {

--- a/output_system/frontend/src/App.tsx
+++ b/output_system/frontend/src/App.tsx
@@ -257,6 +257,15 @@ const App: FC = () => {
   }, [fetchConnections])
 
   /**
+   * 選択中のDB接続先のDB種別（PBI #201 追加: GraphQL時のラベル切替用）
+   *
+   * connections と selectedDbConnectionId から選択中の接続情報を検索し、
+   * dbType を返す。未選択または見つからない場合は undefined。
+   * ChatContainer に渡して ChatMessage -> SQLDisplay のラベル切替に使用する。
+   */
+  const selectedDbType = connections.find((c) => c.id === selectedDbConnectionId)?.dbType
+
+  /**
    * チャット送信ハンドラ（PBI #149 追加: dbConnectionId を含めて送信）
    *
    * ChatContainer の onSend は (message: string) のシグネチャだが、
@@ -386,6 +395,7 @@ const App: FC = () => {
                 isLoading={isLoading}
                 onSend={handleSend}
                 isDbConnectionSelected={!!selectedDbConnectionId}
+                selectedDbType={selectedDbType}
               />
             </main>
           </>

--- a/output_system/frontend/src/components/Chat/ChatContainer.tsx
+++ b/output_system/frontend/src/components/Chat/ChatContainer.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useRef, type FC } from 'react'
-import type { ChatMessage as ChatMessageType } from '../../types'
+import type { ChatMessage as ChatMessageType, DbType } from '../../types'
 import ChatMessage from './ChatMessage'
 import ChatInput from './ChatInput'
 import Loading from '../common/Loading'
@@ -29,6 +29,7 @@ import Loading from '../common/Loading'
  * @property onSend                - メッセージ送信ハンドラ
  * @property isDbConnectionSelected - DB接続先が選択されているかどうか（PBI #149 追加）
  *                                    false の場合はチャット入力を無効化する
+ * @property selectedDbType        - 選択中のDB種別（PBI #201 追加: GraphQL時のラベル切替用）
  */
 interface ChatContainerProps {
   messages: ChatMessageType[]
@@ -36,6 +37,8 @@ interface ChatContainerProps {
   onSend: (message: string) => Promise<void>
   /** DB接続先が選択されているかどうか（false = 未選択でチャット入力を無効化） */
   isDbConnectionSelected?: boolean
+  /** 選択中のDB種別（省略時は 'mysql' として扱う。GraphQL時は 'graphql' を渡す） */
+  selectedDbType?: DbType
 }
 
 /**
@@ -51,6 +54,7 @@ const ChatContainer: FC<ChatContainerProps> = ({
   isLoading,
   onSend,
   isDbConnectionSelected = true,
+  selectedDbType,
 }) => {
   // チャットエリアの最下部へのスクロール用 ref
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -109,8 +113,9 @@ const ChatContainer: FC<ChatContainerProps> = ({
         )}
 
         {/* メッセージリスト */}
+        {/* dbType を渡して GraphQL接続時のラベル切替を有効化（PBI #201） */}
         {messages.map((message) => (
-          <ChatMessage key={message.id} message={message} />
+          <ChatMessage key={message.id} message={message} dbType={selectedDbType} />
         ))}
 
         {/* ローディング表示（ストリーミング開始前の待ち状態） */}

--- a/output_system/frontend/src/components/Chat/ChatMessage.tsx
+++ b/output_system/frontend/src/components/Chat/ChatMessage.tsx
@@ -6,9 +6,13 @@
  *
  * アシスタントメッセージには以下を表示する:
  * - ストリーミングテキスト（StreamingText）
- * - 生成SQL（SQLDisplay）
+ * - 生成SQL または GraphQLクエリ（SQLDisplay: dbType に応じてラベルを切替）
  * - クエリ実行結果（ChartRenderer: Epic 3 PBI 3.1で実装。chart_typeに応じてグラフ/テーブルを描画）
+ * - AI分析コメント（StreamingText）
  * - エラーメッセージ（ErrorMessage）
+ *
+ * PBI #201 更新:
+ * - dbType プロパティを追加（graphql の場合 SQLDisplay のラベルを「GraphQLクエリ」に変更）
  *
  * XSS対策:
  * - ユーザー入力・LLM出力はすべてReactの自動エスケープに任せる
@@ -16,7 +20,7 @@
  */
 
 import type { FC } from 'react'
-import type { ChatMessage as ChatMessageType } from '../../types'
+import type { ChatMessage as ChatMessageType, DbType } from '../../types'
 import StreamingText from './StreamingText'
 import SQLDisplay from '../SQL/SQLDisplay'
 import ChartRenderer from '../Chart/ChartRenderer'
@@ -26,21 +30,29 @@ import ErrorMessage from '../common/ErrorMessage'
  * ChatMessage コンポーネントの Props
  *
  * @property message - 表示するチャットメッセージオブジェクト
+ * @property dbType  - 選択中のDB接続先タイプ（省略時はSQLとして扱う）
+ *                     'graphql' の場合、SQLDisplayのラベルを「生成されたGraphQLクエリ」に変更する
  */
 interface ChatMessageProps {
   message: ChatMessageType
+  /** DB種別（'mysql' / 'postgresql' / 'graphql'）。省略時はSQLとして扱う */
+  dbType?: DbType
 }
 
 /**
  * チャットメッセージ表示コンポーネント
  *
  * user ロール: 右寄せの吹き出しで質問テキストを表示する
- * assistant ロール: 左寄せで応答テキスト・SQL・結果・エラーを表示する
+ * assistant ロール: 左寄せで応答テキスト・SQL/GraphQL・結果・エラーを表示する
  *
  * @param props - ChatMessageProps
  */
-const ChatMessage: FC<ChatMessageProps> = ({ message }) => {
+const ChatMessage: FC<ChatMessageProps> = ({ message, dbType }) => {
   const isUser = message.role === 'user'
+
+  // SQLDisplay に渡すラベル
+  // GraphQL接続の場合は「生成されたGraphQLクエリ」、DB接続の場合は「生成されたSQL」
+  const queryLabel = dbType === 'graphql' ? '生成されたGraphQLクエリ' : '生成されたSQL'
 
   return (
     <div
@@ -77,10 +89,11 @@ const ChatMessage: FC<ChatMessageProps> = ({ message }) => {
           </div>
         )}
 
-        {/* 生成SQL表示（アシスタントメッセージのみ） */}
+        {/* 生成SQL/GraphQLクエリ表示（アシスタントメッセージのみ） */}
+        {/* dbType に応じてラベルを切替（PBI #201）: DB接続="生成されたSQL", GraphQL="生成されたGraphQLクエリ" */}
         {!isUser && message.sql && (
           <div className="chat-message__sql">
-            <SQLDisplay sql={message.sql} />
+            <SQLDisplay sql={message.sql} label={queryLabel} />
           </div>
         )}
 

--- a/output_system/frontend/src/components/SQL/SQLDisplay.tsx
+++ b/output_system/frontend/src/components/SQL/SQLDisplay.tsx
@@ -1,11 +1,15 @@
 /**
  * SQLDisplay コンポーネント
  *
- * LLMが生成したSQL文をコードブロックで表示するコンポーネント。
- * SQL内容はコピーボタン付きで提示する（透明性確保のため）。
+ * LLMが生成したSQL文またはGraphQLクエリをコードブロックで表示するコンポーネント。
+ * クエリ内容はコピーボタン付きで提示する（透明性確保のため）。
+ *
+ * PBI #201 更新:
+ * - label プロパティを追加し、「生成されたSQL」「生成されたGraphQLクエリ」を切り替え可能にした
+ * - GraphQL 接続先の場合は ChatMessage から label="生成されたGraphQLクエリ" が渡される
  *
  * XSS対策:
- * - SQLテキストはReactの自動エスケープに任せる（dangerouslySetInnerHTML禁止）
+ * - クエリテキストはReactの自動エスケープに任せる（dangerouslySetInnerHTML禁止）
  * - シンタックスハイライトは本PBIではプレーンテキスト表示（後続PBIで拡張可能）
  */
 
@@ -14,26 +18,34 @@ import { useState, useCallback, type FC } from 'react'
 /**
  * SQLDisplay コンポーネントの Props
  *
- * @property sql - 表示するSQL文字列
+ * @property sql   - 表示するSQL文字列またはGraphQLクエリ文字列
+ * @property label - ヘッダーに表示するラベル（省略時: "生成されたSQL"）
+ *                   GraphQL接続先の場合は "生成されたGraphQLクエリ" を渡す
  */
 interface SQLDisplayProps {
   sql: string
+  /** ヘッダーラベル。省略時は "生成されたSQL"（GraphQL時は "生成されたGraphQLクエリ"） */
+  label?: string
 }
 
+/** デフォルトのラベル（SQL 接続の場合） */
+const DEFAULT_LABEL = '生成されたSQL'
+
 /**
- * SQL表示コンポーネント
+ * SQL/GraphQL クエリ表示コンポーネント
  *
- * 生成されたSQLをコードブロック形式で表示する。
+ * 生成されたSQL（またはGraphQLクエリ）をコードブロック形式で表示する。
+ * label プロパティで表示ラベルを切り替えられる（DB接続: SQL、GraphQL接続: GraphQL）。
  * コピーボタンでクリップボードへのコピーも可能。
  *
  * @param props - SQLDisplayProps
  */
-const SQLDisplay: FC<SQLDisplayProps> = ({ sql }) => {
+const SQLDisplay: FC<SQLDisplayProps> = ({ sql, label = DEFAULT_LABEL }) => {
   // コピー完了フラグ（ボタンラベルの一時的な変更に使用）
   const [copied, setCopied] = useState(false)
 
   /**
-   * SQLをクリップボードにコピーする
+   * クエリをクリップボードにコピーする
    * コピー成功後、2秒間「コピー済み」表示に切り替える
    */
   const handleCopy = useCallback(async () => {
@@ -52,12 +64,13 @@ const SQLDisplay: FC<SQLDisplayProps> = ({ sql }) => {
     <div className="sql-display">
       {/* ヘッダー: ラベル + コピーボタン */}
       <div className="sql-header">
-        <span className="sql-label">生成されたSQL</span>
+        {/* DB接続: "生成されたSQL" / GraphQL接続: "生成されたGraphQLクエリ" */}
+        <span className="sql-label">{label}</span>
         <button
           className="sql-copy-btn"
           onClick={handleCopy}
           type="button"
-          aria-label="SQLをコピー"
+          aria-label={`${label}をコピー`}
           title="クリップボードにコピー"
         >
           {copied ? '✓ コピー済み' : 'コピー'}

--- a/output_system/test/unit/graphqlExecutor.test.ts
+++ b/output_system/test/unit/graphqlExecutor.test.ts
@@ -1,0 +1,402 @@
+/**
+ * 【モジュール】backend/src/services/graphqlExecutor.ts
+ * GraphQLクエリ実行サービスのユニットテスト
+ *
+ * このファイルでは GraphQL Executor の以下の挙動を検証する:
+ * - flattenObject: ネストしたオブジェクトのフラット化
+ * - formatGraphQLResult: GraphQLレスポンスの rows/columns 形式への変換
+ * - executeGraphQLQuery: バリデーションと実行（fetch モック）
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  flattenObject,
+  formatGraphQLResult,
+  executeGraphQLQuery,
+  GraphQLValidationError,
+  GraphQLApiError,
+  GraphQLTimeoutError,
+  GraphQLConnectionError,
+} from '../../backend/src/services/graphqlExecutor'
+
+// =============================================================================
+// flattenObject テスト
+// =============================================================================
+
+/**
+ * 【モジュール】flattenObject
+ * ネストしたオブジェクトのフラット化テスト
+ */
+describe('flattenObject', () => {
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】フラットなオブジェクト（ネストなし）を渡した場合
+   * 【期待結果】元のオブジェクトがそのまま返ること
+   */
+  it('should return flat object unchanged', () => {
+    const obj = { id: 1, name: 'Alice', active: true }
+    const result = flattenObject(obj)
+    expect(result).toEqual({ id: 1, name: 'Alice', active: true })
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】1階層ネストしたオブジェクトを渡した場合
+   * 【期待結果】ドット記法のキー名でフラット化されること
+   *
+   * 入力例: { user: { name: "Alice", age: 30 } }
+   * 期待値: { "user.name": "Alice", "user.age": 30 }
+   */
+  it('should flatten one level of nesting with dot notation', () => {
+    const obj = { user: { name: 'Alice', age: 30 } }
+    const result = flattenObject(obj)
+    expect(result).toEqual({ 'user.name': 'Alice', 'user.age': 30 })
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】複数階層にネストしたオブジェクトを渡した場合
+   * 【期待結果】全階層がドット記法でフラット化されること
+   *
+   * 入力例: { a: { b: { c: "value" } } }
+   * 期待値: { "a.b.c": "value" }
+   */
+  it('should flatten multiple levels of nesting', () => {
+    const obj = { a: { b: { c: 'value' } } }
+    const result = flattenObject(obj)
+    expect(result).toEqual({ 'a.b.c': 'value' })
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】配列を含むオブジェクトを渡した場合
+   * 【期待結果】配列はそのまま保持されること（再帰的にフラット化しない）
+   *
+   * 入力例: { items: [{ id: 1 }, { id: 2 }] }
+   * 期待値: { items: [{ id: 1 }, { id: 2 }] }
+   */
+  it('should keep arrays as-is without flattening', () => {
+    const obj = { items: [{ id: 1 }, { id: 2 }] }
+    const result = flattenObject(obj)
+    expect(result).toEqual({ items: [{ id: 1 }, { id: 2 }] })
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】null 値を含むオブジェクトを渡した場合
+   * 【期待結果】null 値がそのまま保持されること
+   */
+  it('should keep null values as-is', () => {
+    const obj = { name: 'Alice', email: null }
+    const result = flattenObject(obj)
+    expect(result).toEqual({ name: 'Alice', email: null })
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】空のオブジェクトを渡した場合
+   * 【期待結果】空のオブジェクトが返ること
+   */
+  it('should return empty object for empty input', () => {
+    const result = flattenObject({})
+    expect(result).toEqual({})
+  })
+
+  /**
+   * 【テスト対象】flattenObject
+   * 【テスト内容】混在したオブジェクト（ネスト・配列・スカラー）を渡した場合
+   * 【期待結果】ネストした部分のみフラット化され、配列・スカラーはそのまま保持されること
+   */
+  it('should handle mixed nested and flat fields', () => {
+    const obj = {
+      id: 1,
+      user: { name: 'Alice', role: 'admin' },
+      tags: ['a', 'b'],
+    }
+    const result = flattenObject(obj)
+    expect(result).toEqual({
+      id: 1,
+      'user.name': 'Alice',
+      'user.role': 'admin',
+      tags: ['a', 'b'],
+    })
+  })
+})
+
+// =============================================================================
+// formatGraphQLResult テスト
+// =============================================================================
+
+/**
+ * 【モジュール】formatGraphQLResult
+ * GraphQLレスポンスの data 部分を rows/columns 形式に変換するテスト
+ */
+describe('formatGraphQLResult', () => {
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】配列結果を含む data オブジェクトを渡した場合
+   * 【期待結果】columns と rows が正しく抽出されること
+   *
+   * 入力例: { users: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+   * 期待値: { columns: ['id', 'name'], rows: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+   */
+  it('should convert array data to columns and rows', () => {
+    const data = {
+      users: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+    }
+    const result = formatGraphQLResult(data)
+    expect(result.columns).toContain('id')
+    expect(result.columns).toContain('name')
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0]).toEqual({ id: 1, name: 'Alice' })
+    expect(result.rows[1]).toEqual({ id: 2, name: 'Bob' })
+  })
+
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】単一オブジェクト結果を含む data を渡した場合
+   * 【期待結果】1行として扱われること
+   *
+   * 入力例: { user: { id: 1, name: 'Alice' } }
+   * 期待値: { columns: ['id', 'name'], rows: [{ id: 1, name: 'Alice' }] }
+   */
+  it('should convert single object data to one row', () => {
+    const data = { user: { id: 1, name: 'Alice' } }
+    const result = formatGraphQLResult(data)
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]).toEqual({ id: 1, name: 'Alice' })
+  })
+
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】ネストしたオブジェクトを含む data を渡した場合
+   * 【期待結果】ネストしたフィールドがフラット化されること
+   *
+   * 入力例: { users: [{ id: 1, profile: { bio: 'hello' } }] }
+   * 期待値: { columns: ['id', 'profile.bio'], rows: [{ id: 1, 'profile.bio': 'hello' }] }
+   */
+  it('should flatten nested objects in rows', () => {
+    const data = {
+      users: [{ id: 1, profile: { bio: 'hello' } }],
+    }
+    const result = formatGraphQLResult(data)
+    expect(result.columns).toContain('id')
+    expect(result.columns).toContain('profile.bio')
+    expect(result.rows[0]['profile.bio']).toBe('hello')
+  })
+
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】空の配列を含む data を渡した場合
+   * 【期待結果】columns が空配列、rows が空配列で返ること
+   */
+  it('should return empty columns and rows for empty array', () => {
+    const data = { users: [] }
+    const result = formatGraphQLResult(data)
+    expect(result.columns).toEqual([])
+    expect(result.rows).toEqual([])
+  })
+
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】空のオブジェクトを渡した場合
+   * 【期待結果】columns が空配列、rows が空配列で返ること
+   */
+  it('should return empty result for empty data object', () => {
+    const result = formatGraphQLResult({})
+    expect(result.columns).toEqual([])
+    expect(result.rows).toEqual([])
+  })
+
+  /**
+   * 【テスト対象】formatGraphQLResult
+   * 【テスト内容】プリミティブ値（数値）を含む data を渡した場合
+   * 【期待結果】1行1列として扱われること
+   */
+  it('should handle primitive scalar result', () => {
+    const data = { count: 42 }
+    const result = formatGraphQLResult(data)
+    expect(result.columns).toContain('count')
+    expect(result.rows[0]).toEqual({ count: 42 })
+  })
+})
+
+// =============================================================================
+// executeGraphQLQuery テスト（fetch モック）
+// =============================================================================
+
+/**
+ * 【モジュール】executeGraphQLQuery
+ * GraphQLクエリ実行のテスト（グローバル fetch をモック）
+ */
+describe('executeGraphQLQuery', () => {
+  beforeEach(() => {
+    // fetch をモックする
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】Mutation キーワードを含むクエリを実行しようとした場合
+   * 【期待結果】GraphQLValidationError がスローされること（fetch は呼ばれない）
+   */
+  it('should throw GraphQLValidationError for mutation query', async () => {
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', 'mutation { createUser { id } }')
+    ).rejects.toThrow(GraphQLValidationError)
+    // バリデーションで弾かれるため fetch は呼ばれない
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】Subscription キーワードを含むクエリを実行しようとした場合
+   * 【期待結果】GraphQLValidationError がスローされること
+   */
+  it('should throw GraphQLValidationError for subscription query', async () => {
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', 'subscription { userCreated { id } }')
+    ).rejects.toThrow(GraphQLValidationError)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】有効なクエリでエンドポイントが正常応答した場合
+   * 【期待結果】rows/columns 形式の結果が返ること
+   */
+  it('should return query result for valid query with successful response', async () => {
+    const mockResponse = {
+      data: {
+        users: [
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ],
+      },
+    }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    const result = await executeGraphQLQuery(
+      'https://api.example.com/graphql',
+      '{ users { id name } }'
+    )
+    expect(result.columns).toContain('id')
+    expect(result.columns).toContain('name')
+    expect(result.rows).toHaveLength(2)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】GraphQLエンドポイントが errors 配列のみを返した場合
+   * 【期待結果】GraphQLApiError がスローされること
+   */
+  it('should throw GraphQLApiError when response contains only errors', async () => {
+    const mockResponse = {
+      errors: [{ message: 'Field "unknownField" not found' }],
+    }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', '{ unknownField }')
+    ).rejects.toThrow(GraphQLApiError)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】HTTP エラー（404）が返った場合
+   * 【期待結果】GraphQLConnectionError がスローされること
+   */
+  it('should throw GraphQLConnectionError for HTTP error response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response)
+
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', '{ users { id } }')
+    ).rejects.toThrow(GraphQLConnectionError)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】fetch が AbortError をスローした場合（タイムアウト）
+   * 【期待結果】GraphQLTimeoutError がスローされること
+   */
+  it('should throw GraphQLTimeoutError when fetch is aborted', async () => {
+    const abortError = new DOMException('The operation was aborted.', 'AbortError')
+    vi.mocked(fetch).mockRejectedValueOnce(abortError)
+
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', '{ users { id } }')
+    ).rejects.toThrow(GraphQLTimeoutError)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】fetch がネットワークエラーをスローした場合
+   * 【期待結果】GraphQLConnectionError がスローされること
+   */
+  it('should throw GraphQLConnectionError for network error', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+
+    await expect(
+      executeGraphQLQuery('https://api.example.com/graphql', '{ users { id } }')
+    ).rejects.toThrow(GraphQLConnectionError)
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】部分成功（data と errors の両方が存在）の場合
+   * 【期待結果】data 部分が結果として返ること（エラーは無視される）
+   */
+  it('should return data part when both data and errors are present (partial success)', async () => {
+    const mockResponse = {
+      data: { users: [{ id: 1, name: 'Alice' }] },
+      errors: [{ message: 'Some non-critical error' }],
+    }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    const result = await executeGraphQLQuery(
+      'https://api.example.com/graphql',
+      '{ users { id name } }'
+    )
+    // 部分成功: data 部分を結果として返す
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]).toEqual({ id: 1, name: 'Alice' })
+  })
+
+  /**
+   * 【テスト対象】executeGraphQLQuery
+   * 【テスト内容】空の data を含むレスポンスが返った場合
+   * 【期待結果】空の columns と rows が返ること
+   */
+  it('should return empty result for empty data response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: {} }),
+    } as Response)
+
+    const result = await executeGraphQLQuery(
+      'https://api.example.com/graphql',
+      '{ users { id } }'
+    )
+    expect(result.columns).toEqual([])
+    expect(result.rows).toEqual([])
+  })
+})

--- a/output_system/test/unit/graphqlValidator.test.ts
+++ b/output_system/test/unit/graphqlValidator.test.ts
@@ -1,0 +1,228 @@
+/**
+ * 【モジュール】backend/src/services/graphqlValidator.ts
+ * GraphQLクエリバリデーターサービスのユニットテスト
+ *
+ * このファイルでは GraphQL バリデーターの以下の挙動を検証する:
+ * - 許可パターン: shorthand query ({ ... }), 名前付き query (query { ... })
+ * - 拒否パターン: mutation, subscription, 空文字
+ * - コメント除去後のバリデーション
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateGraphQL } from '../../backend/src/services/graphqlValidator'
+
+/**
+ * 【モジュール】validateGraphQL
+ * GraphQLクエリバリデーションの全挙動テスト
+ */
+describe('validateGraphQL', () => {
+  // ---------------------------------------------------------------------------
+  // 許可パターン
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】shorthand query（{ で始まるクエリ）を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow shorthand query starting with {', () => {
+    const result = validateGraphQL('{ users { id name } }')
+    expect(result.ok).toBe(true)
+    expect(result.sanitizedQuery).toBeTruthy()
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】キーワード付き query（query { ... }）を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow named query with "query" keyword', () => {
+    const result = validateGraphQL('query GetUsers { users { id name } }')
+    expect(result.ok).toBe(true)
+    expect(result.sanitizedQuery).toBeTruthy()
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】複数行にわたる複雑な query を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow complex multi-line query', () => {
+    const query = `
+      query GetProducts {
+        products(limit: 10) {
+          id
+          name
+          price
+          category {
+            name
+          }
+        }
+      }
+    `
+    const result = validateGraphQL(query)
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】引数付きの query を渡した場合
+   * 【期待結果】ok: true が返ること
+   */
+  it('should allow query with arguments', () => {
+    const result = validateGraphQL('{ user(id: "123") { name email } }')
+    expect(result.ok).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 拒否パターン: mutation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】mutation キーワードを含むクエリを渡した場合
+   * 【期待結果】ok: false が返り、mutation 禁止のメッセージが含まれること
+   */
+  it('should reject query with mutation keyword', () => {
+    const result = validateGraphQL('mutation CreateUser { createUser(name: "Alice") { id } }')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('mutation')
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】小文字の mutation キーワードを含むクエリを渡した場合
+   * 【期待結果】ok: false が返ること（大文字小文字を無視して検出する）
+   */
+  it('should reject mutation keyword regardless of case', () => {
+    const result = validateGraphQL('MUTATION CreateUser { createUser(name: "Alice") { id } }')
+    expect(result.ok).toBe(false)
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】mutation を含むショートハンドクエリを渡した場合
+   * 【期待結果】ok: false が返ること
+   */
+  it('should reject any query containing mutation keyword', () => {
+    const result = validateGraphQL('{ mutation { someField } }')
+    expect(result.ok).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 拒否パターン: subscription
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】subscription キーワードを含むクエリを渡した場合
+   * 【期待結果】ok: false が返ること
+   */
+  it('should reject query with subscription keyword', () => {
+    const result = validateGraphQL('subscription OnUserCreated { userCreated { id name } }')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('subscription')
+  })
+
+  // ---------------------------------------------------------------------------
+  // 拒否パターン: 空文字・空白
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】空文字を渡した場合
+   * 【期待結果】ok: false が返り、空クエリのメッセージが含まれること
+   */
+  it('should reject empty string', () => {
+    const result = validateGraphQL('')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBeTruthy()
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】空白のみの文字列を渡した場合
+   * 【期待結果】ok: false が返ること
+   */
+  it('should reject whitespace-only string', () => {
+    const result = validateGraphQL('   \n\t  ')
+    expect(result.ok).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 拒否パターン: 無効な開始キーワード
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】fragment 定義のみを渡した場合
+   * 【期待結果】ok: false が返ること（query/shorthand queryで始まらないため）
+   */
+  it('should reject fragment-only definition', () => {
+    const result = validateGraphQL('fragment UserFields on User { id name }')
+    expect(result.ok).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // コメント除去
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】GraphQL の行コメント（#）を含むクエリを渡した場合
+   * 【期待結果】コメント除去後に ok: true が返ること
+   */
+  it('should handle GraphQL line comments (#)', () => {
+    const query = `
+      # Get all users
+      {
+        users {
+          id # user id
+          name
+        }
+      }
+    `
+    const result = validateGraphQL(query)
+    expect(result.ok).toBe(true)
+  })
+
+  /**
+   * 【テスト対象】validateGraphQL
+   * 【テスト内容】コメント内に mutation キーワードを含むクエリを渡した場合
+   * 【期待結果】ok: false が返ること（コメント除去後もチェックを行う）
+   *
+   * 注意: GraphQL のコメント（#）除去後に mutation が残る場合は拒否する。
+   * コメントインジェクション攻撃の防止ではなく、誤ってコメント内に mutation を
+   * 書いてしまったケースを含めて一貫してチェックする。
+   */
+  it('should reject query with mutation in comment when query text contains mutation', () => {
+    // コメント除去後に mutation が現れるケースは拒否する設計ではなく、
+    // クエリ本体に mutation が含まれる場合を検出することが目的
+    const query = `
+      # This is a mutation comment
+      { users { id } }
+    `
+    // コメント「# This is a mutation comment」を除去すると mutation キーワードは残らない
+    // したがって ok: true になる（コメント内の mutation は問題なし）
+    const result = validateGraphQL(query)
+    // コメント除去後に { users { id } } だけ残るので ok: true を期待
+    expect(result.ok).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // sanitizedQuery の確認
+  // ---------------------------------------------------------------------------
+
+  /**
+   * 【テスト対象】validateGraphQL の sanitizedQuery
+   * 【テスト内容】有効なクエリを渡した場合の sanitizedQuery の形式
+   * 【期待結果】sanitizedQuery が正規化された文字列であること
+   */
+  it('should return sanitizedQuery for valid query', () => {
+    const result = validateGraphQL('  query   GetUsers  {  users  { id }  }  ')
+    expect(result.ok).toBe(true)
+    expect(result.sanitizedQuery).toBeDefined()
+    // 正規化: 前後の空白が除去され、連続空白が単一スペースになる
+    expect(result.sanitizedQuery?.startsWith('query')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

データ分析ユーザーが GraphQL 接続先に対して自然言語で質問し、LLM が自動で GraphQL Query を生成・実行して結果をグラフ・テーブルで可視化できるようにする。GraphQL の知識がなくても社内 API のデータ分析が可能になる。

### 実装内容

**対象PBI**: #201 GraphQL APIに自然言語で問い合わせてデータを可視化できる

- #206 Task 5.2.1: GraphQLクエリ生成用LLMプロンプトを実装する ✅
- #207 Task 5.2.2: GraphQLクエリ実行・バリデーション・結果整形を実装する ✅
- #208 Task 5.2.3: GraphQLエラーハンドリングを実装する ✅
- #209 Task 5.2.4: GraphQL結果の可視化・会話分離・AI分析を実装する ✅

### 変更ファイル

**バックエンド**
- `output_system/backend/src/services/llm.ts`: GraphQL用システムプロンプト強化（Mutation禁止、フラット構造指示、JSON レスポンスフォーマット追加）; `schemaToPromptText` を GraphQL に対応（Type/Field 表示）; `analyzeResults` に `dbType` パラメータ追加
- `output_system/backend/src/services/graphqlValidator.ts` (新規): Mutation/Subscription/空クエリ拒否バリデーター
- `output_system/backend/src/services/graphqlExecutor.ts` (新規): fetch API による GraphQL クエリ実行、ネスト→フラット化、rows/columns 形式変換、型別エラークラス
- `output_system/backend/src/routes/chat.ts`: `schema.dbType === 'graphql'` による実行パス分岐、GraphQL エラーハンドリング（タイムアウト・フィールドエラー等のガイドメッセージ）

**フロントエンド**
- `output_system/frontend/src/App.tsx`: `selectedDbType` 算出ロジック追加、`ChatContainer` に `selectedDbType` を props 渡し
- `output_system/frontend/src/components/Chat/ChatContainer.tsx`: `selectedDbType` prop 追加、`ChatMessage` に伝播
- `output_system/frontend/src/components/Chat/ChatMessage.tsx`: `dbType` prop 追加、GraphQL 接続時に `queryLabel = "生成されたGraphQLクエリ"` を `SQLDisplay` に渡す
- `output_system/frontend/src/components/SQL/SQLDisplay.tsx`: `label` prop 追加（省略時: "生成されたSQL"）、GraphQL 接続時は "生成されたGraphQLクエリ" を表示

**テスト**
- `output_system/test/unit/graphqlValidator.test.ts` (新規): 14テストケース（Query許可・Mutation/Subscription拒否・コメント除去等）
- `output_system/test/unit/graphqlExecutor.test.ts` (新規): 22テストケース（flattenObject・formatGraphQLResult・executeGraphQLQuery の各挙動）

## Test Plan

- [ ] GraphQL接続先選択時にチャットで自然言語の質問を入力するとGraphQLクエリが自動生成される
- [ ] 生成されたGraphQLクエリがチャット画面に「生成されたGraphQLクエリ」ラベル付きで表示される
- [ ] GraphQLクエリはQueryのみ許可され、Mutationを含むクエリは拒否される（GraphQLValidationError）
- [ ] GraphQLクエリが選択中のエンドポイントに対して実行され、結果が取得される
- [ ] GraphQL結果が棒グラフ・折れ線グラフ・円グラフ・テーブルで可視化される
- [ ] LLMがフラットなデータ構造を返すGraphQLクエリを生成する
- [ ] GraphQL接続先ごとに会話履歴が分離される（既存のdbConnectionIdベース）
- [ ] GraphQLのerrors配列でエラーが返った場合、種別に応じたガイドメッセージが表示される
- [ ] GraphQLクエリ結果に対してLLMがAI分析コメントをストリーミング表示する
- [ ] 既存のDB接続先でのSQL生成・実行・可視化フローが影響を受けない

## Screenshots

| 画面名 | スクリーンショット |
|--------|-------------------|
| アプリ起動 | ![起動画面](https://github.com/okegawaatclink/gaido-dataagent/raw/f33ce788acdd5865f599e073f14e9b93f3708710/ai_generated/screenshots/pbi201_rebuilt.png) |

## Related Issues

- Closes #201

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)